### PR TITLE
D1: 统一组件状态内核

### DIFF
--- a/docs/superpowers/reviews/2026-09-04-d1-state-kernel.md
+++ b/docs/superpowers/reviews/2026-09-04-d1-state-kernel.md
@@ -1,0 +1,52 @@
+# D1 组件状态内核验收记录
+
+## 范围
+
+- 新增内部 `useControllableState`、`useStableId`、`useAsyncTask`、`useCollection`、`useRovingFocus`。
+- 首批迁移 Select、Cascader、TreeSelect、DatePicker/DateRangePicker、TimePicker/TimeRangePicker、Table、Upload。
+- `default*` 只用于初始化；受控父组件是唯一事实源，拒绝更新时不得乐观漂移。
+
+不包含公开 API/类型导出、D2 浮层栈、Table 数据模式/缺失 rowKey 策略、虚拟化、DnD 包或 AI 包改造。
+
+## 开发实施
+
+- `useControllableState` 支持运行时接管/释放控制、显式 `undefined` 受控值、函数更新、`Object.is` 去重及必要的强制通知。
+- `useStableId` 基于 Vue `useId`，生成 CSS 安全、SSR 稳定的内部 ID，并保留显式 ID 覆盖。
+- `useAsyncTask` 处理 abort、请求版本、迟到成功/失败、错误恢复和卸载清理。
+- `useCollection` 管理稳定 key、注册顺序、可见/禁用状态；`useRovingFocus` 统一方向键、Home/End、循环与禁用跳过。
+- 各迁移组件继续使用原 props/events/types，状态桥接改由内部 helper 管理。
+
+## 开发经理复审
+
+- [x] helper 不从公共入口导出，未改变包边界或主要依赖。
+- [x] 受控/非受控切换、显式 undefined、默认值初始化语义一致。
+- [x] Picker 草稿/确认、Table 选择/展开/分页、Upload 迟到回调语义未回退。
+- [x] source 与 es/lib 生成产物一致，diff 无无关漂移。
+
+## 测试经理测试
+
+- [x] 五个 helper 契约测试通过。
+- [x] 迁移组件专项与 SSR 测试通过。
+- [x] 全量 unit、typecheck、构建确定性、docs build、三包 tarball 通过。
+- [x] 关键生产 E2E 与跨浏览器 R1 冒烟通过（Desktop WebKit R1 8/8）。
+- [ ] GitHub PR CI 与 master CI 全绿。
+
+## 设计审核
+
+- [x] 无 CSS、视觉 token、用户文案或布局变化。
+- [x] Select、Picker、Table、Upload 关键页面截图无未解释差异（QG4 desktop 14 passed / 3 skipped）。
+- [x] 键盘焦点、ARIA ID 与父拒绝更新的可观察行为保持一致。
+
+## 产品经理最终验收
+
+- [x] 非受控用户操作后，父层改变 `default*` 不覆盖当前值。
+- [x] 受控父层拒绝 value/open/selection/page 更新时，界面不漂移。
+- [x] 父层在挂载后接管受控状态时，界面立即以父层值为准。
+- [ ] P1/P2 为零，PR 留存完成，合并 master 后远端 CI 绿色。
+
+## GitHub 留存
+
+- 分支：`codex/d1-state-kernel`
+- PR：待创建
+- 合并提交：待完成
+- master CI：待完成

--- a/packages/components/es/cascader/cascader.vue.js
+++ b/packages/components/es/cascader/cascader.vue.js
@@ -4,6 +4,7 @@ import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import "./style.css.js";
 const _hoisted_1 = ["tabindex", "aria-expanded", "aria-disabled"];
@@ -60,16 +61,32 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const triggerRef = ref(null);
     const panelRef = ref(null);
     const columnsRef = ref(null);
-    const innerOpen = ref(props.defaultOpen);
     const searchText = ref("");
     const activePath = ref([]);
     const loadingPaths = ref([]);
     const innerOptions = ref(cloneOptions(props.options));
-    const innerValue = ref(props.defaultValue);
     const isControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
-    const mergedOpen = computed(() => isOpenControlled.value ? props.open : innerOpen.value);
-    const mergedValue = computed(() => isControlled.value ? props.modelValue : innerValue.value);
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => {
+        const nextOpen = Boolean(open);
+        emit("openChange", nextOpen);
+      }
+    });
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => {
+        emit("update:modelValue", value);
+        emit("change", value);
+      }
+    });
+    const mergedOpen = computed(() => Boolean(openState.state.value));
+    const mergedValue = valueState.state;
     const selectedPaths = computed(() => {
       if (props.multiple) {
         return Array.isArray(mergedValue.value) && mergedValue.value.every(Array.isArray) ? mergedValue.value : [];
@@ -153,16 +170,11 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const requestOpen = (open) => {
       if (props.disabled)
         return;
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
     };
     const toggleOpen = () => requestOpen(!mergedOpen.value);
     const emitValue = (value) => {
-      if (!isControlled.value)
-        innerValue.value = value;
-      emit("update:modelValue", value);
-      emit("change", value);
+      valueState.setState(value, { force: true });
     };
     const clearValue = () => {
       emitValue(props.multiple ? [] : void 0);
@@ -286,10 +298,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       trigger: triggerRef,
       floating: panelRef,
       onDismiss: () => requestOpen(false)
-    });
-    watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
     });
     return (_ctx, _cache) => {
       return openBlock(), createElementBlock("div", {

--- a/packages/components/es/date-picker/date-picker.vue.js
+++ b/packages/components/es/date-picker/date-picker.vue.js
@@ -1,4 +1,4 @@
-import { defineComponent, useSlots, ref, useId, isVNode, h, toRaw, computed, onMounted, watch, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, Fragment, renderList, createTextVNode, toDisplayString, withModifiers, createBlock, Teleport, withDirectives, normalizeStyle, mergeProps, vShow } from "vue";
+import { defineComponent, useSlots, ref, isVNode, h, toRaw, computed, onMounted, watch, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, Fragment, renderList, createTextVNode, toDisplayString, withModifiers, createBlock, Teleport, withDirectives, normalizeStyle, mergeProps, vShow } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import { createDateMatrix, isPickerDateDisabled } from "../picker-core/calendar.js";
 import { defaultValueFormat, normalizeFormats, parsePickerValue, formatPickerValue } from "../picker-core/codec.js";
@@ -7,7 +7,9 @@ import { normalizeMultipleValues } from "../picker-core/selection.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import { datePickerProps, datePickerEmits } from "./types.js";
 import "./style.css.js";
@@ -72,17 +74,26 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const triggerRef = ref(null);
     const inputRef = ref(null);
     const panelRef = ref(null);
-    const internalValue = ref(props.defaultValue);
-    const internalOpen = ref(props.defaultOpen);
     const draftValue = ref();
     const inputText = ref("");
     const activeCellKey = ref("");
     const liveMessage = ref("");
-    const instanceId = useId().replace(/:/g, "");
-    const panelId = `aheart-date-picker-${instanceId}-panel`;
+    const panelId = `${useStableId(void 0, "aheart-date-picker").value}-panel`;
     const isValueControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
     const isPanelControlled = usePropPresence("pickerValue", "picker-value");
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = defineComponent({
       name: "ADatePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -94,8 +105,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         };
       }
     });
-    const mergedValue = computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = computed(() => Boolean(openState.state.value));
     const selectedValues = computed(() => Array.isArray(mergedValue.value) ? mergedValue.value : mergedValue.value ? [mergedValue.value] : []);
     const effectiveShowTime = computed(() => Boolean(props.showTime) && !props.multiple && props.picker === "date");
     const showTimeOptions = computed(() => typeof props.showTime === "object" ? props.showTime : {});
@@ -290,9 +301,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         return;
       if (!nextOpen)
         restoreFocusOnClose = restoreFocus;
-      if (!isOpenControlled.value)
-        internalOpen.value = nextOpen;
-      emit("openChange", nextOpen);
+      openState.setState(nextOpen, { force: true });
     };
     let restoringFocus = false;
     const handleFocus = () => {
@@ -330,9 +339,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     });
     const commitValue = (value, close = true) => {
       const normalized = Array.isArray(value) ? normalizeMultipleValues(value) : value;
-      if (!isValueControlled.value)
-        internalValue.value = normalized;
-      emit("update:modelValue", normalized);
+      valueState.setState(normalized, { force: true });
       emit("change", normalized);
       if (isValueControlled.value) {
         void nextTick(() => {

--- a/packages/components/es/date-picker/date-range-picker.vue.js
+++ b/packages/components/es/date-picker/date-range-picker.vue.js
@@ -1,4 +1,4 @@
-import { defineComponent, useSlots, ref, useId, isVNode, h, toRaw, computed, watch, onMounted, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, withModifiers, createBlock, Teleport, withDirectives, normalizeStyle, Fragment, renderList, toDisplayString, mergeProps, createTextVNode, vShow } from "vue";
+import { defineComponent, useSlots, ref, isVNode, h, toRaw, computed, watch, onMounted, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, withModifiers, createBlock, Teleport, withDirectives, normalizeStyle, Fragment, renderList, toDisplayString, mergeProps, createTextVNode, vShow } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import { createDateMatrix, isPickerDateDisabled } from "../picker-core/calendar.js";
 import { defaultValueFormat, normalizeFormats, parsePickerValue, formatPickerValue, comparePickerValues } from "../picker-core/codec.js";
@@ -7,7 +7,9 @@ import { normalizeRangeValue, advanceRangeSelection } from "../picker-core/selec
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import { dateRangePickerProps, dateRangePickerEmits } from "./types.js";
 import "./style.css.js";
@@ -78,8 +80,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const panelRef = ref(null);
     const startInputRef = ref(null);
     const endInputRef = ref(null);
-    const internalValue = ref(props.defaultValue ? [...props.defaultValue] : void 0);
-    const internalOpen = ref(props.defaultOpen);
     const draftValue = ref();
     const activePart = ref("start");
     const activeKeyboardDate = ref();
@@ -89,10 +89,22 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const inputTexts = ref(["", ""]);
     const nowDate = ref();
     const rangeParts = ["start", "end"];
-    const panelId = `aheart-date-range-picker-${useId().replace(/:/g, "")}-panel`;
+    const panelId = `${useStableId(void 0, "aheart-date-range-picker").value}-panel`;
     const isValueControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
     const isPanelControlled = usePropPresence("pickerValue", "picker-value");
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue ? [...props.defaultValue] : void 0,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = defineComponent({
       name: "ADateRangePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -104,8 +116,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         };
       }
     });
-    const mergedValue = computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = computed(() => Boolean(openState.state.value));
     const effectiveShowTime = computed(() => Boolean(props.showTime) && props.picker === "date");
     const showTimeOptions = computed(() => typeof props.showTime === "object" ? props.showTime : {});
     const effectiveNeedConfirm = computed(() => props.needConfirm ?? effectiveShowTime.value);
@@ -311,9 +323,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const requestOpen = (open, restoreFocus = false) => {
       if (open && (isDisabled.value || props.readOnly))
         return;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (!open && restoreFocus)
         void nextTick(() => {
           var _a;
@@ -469,9 +479,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     const commitValue = (value, close = true) => {
       const normalized = normalizeRangeValue(value, resolvedValueFormat.value, props.order, props.allowEmpty) ?? value;
-      if (!isValueControlled.value)
-        internalValue.value = normalized ? [...normalized] : void 0;
-      emit("update:modelValue", normalized);
+      valueState.setState(normalized ? [...normalized] : void 0, { force: true });
       emit("change", normalized);
       if (isValueControlled.value)
         void nextTick(syncInputs);
@@ -669,7 +677,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
               onChange: _cache[2] || (_cache[2] = ($event) => commitInput("start")),
               onKeydown: handleInputKeydown
             }, null, 40, _hoisted_2),
-            _ctx.allowClear && ((_a = mergedValue.value) == null ? void 0 : _a[0]) && _ctx.allowEmpty[0] && !isDisabled.value && !_ctx.readOnly ? (openBlock(), createElementBlock("button", {
+            _ctx.allowClear && ((_a = unref(mergedValue)) == null ? void 0 : _a[0]) && _ctx.allowEmpty[0] && !isDisabled.value && !_ctx.readOnly ? (openBlock(), createElementBlock("button", {
               key: 0,
               "data-range-clear": "start",
               type: "button",
@@ -719,7 +727,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
               onChange: _cache[6] || (_cache[6] = ($event) => commitInput("end")),
               onKeydown: handleInputKeydown
             }, null, 40, _hoisted_5),
-            _ctx.allowClear && ((_b = mergedValue.value) == null ? void 0 : _b[1]) && _ctx.allowEmpty[1] && !isDisabled.value && !_ctx.readOnly ? (openBlock(), createElementBlock("button", {
+            _ctx.allowClear && ((_b = unref(mergedValue)) == null ? void 0 : _b[1]) && _ctx.allowEmpty[1] && !isDisabled.value && !_ctx.readOnly ? (openBlock(), createElementBlock("button", {
               key: 0,
               "data-range-clear": "end",
               type: "button",

--- a/packages/components/es/select/select.vue.js
+++ b/packages/components/es/select/select.vue.js
@@ -1,9 +1,11 @@
-import { defineComponent, useSlots, useAttrs, ref, useId, computed, watch, openBlock, createElementBlock, mergeProps, createElementVNode, normalizeClass, normalizeStyle, renderSlot, createVNode, unref, createCommentVNode, Fragment, renderList, withModifiers, toDisplayString, createBlock, Teleport, withDirectives, vShow, nextTick } from "vue";
+import { defineComponent, useSlots, useAttrs, ref, computed, watch, openBlock, createElementBlock, mergeProps, createElementVNode, normalizeClass, normalizeStyle, renderSlot, createVNode, unref, createCommentVNode, Fragment, renderList, withModifiers, toDisplayString, createBlock, Teleport, withDirectives, vShow, nextTick } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import { selectProps, selectEmits } from "./types.js";
 import "./style.css.js";
@@ -46,12 +48,9 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const searchRef = ref(null);
     const popupRef = ref(null);
     const internalSearchValue = ref("");
-    const internalValue = ref(props.defaultValue);
-    const internalOpen = ref(props.defaultOpen);
     const activeIndex = ref(-1);
     const focused = ref(false);
-    const instanceId = useId().replace(/:/g, "");
-    const listboxId = `aheart-select-${instanceId}-listbox`;
+    const listboxId = `${useStableId(void 0, "aheart-select").value}-listbox`;
     const ARenderNode = defineComponent({
       name: "ASelectRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -76,10 +75,27 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const isMultiple = computed(() => props.mode === "multiple" || props.mode === "tags");
     const isSearchable = computed(() => props.showSearch || props.mode === "tags");
     const isControlled = usePropPresence("modelValue", "model-value");
-    const mergedValue = computed(() => isControlled.value ? props.modelValue : internalValue.value);
     const isOpenControlled = usePropPresence("open");
     const isSearchControlled = usePropPresence("searchValue", "search-value");
-    const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => {
+        if (value === void 0)
+          return;
+        emit("update:modelValue", value);
+        emit("change", value);
+      }
+    });
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
+    const mergedValue = valueState.state;
+    const mergedOpen = computed(() => Boolean(openState.state.value));
     const currentSearchValue = computed(() => isSearchControlled.value ? props.searchValue ?? "" : internalSearchValue.value);
     const resolvedAriaLabelledby = computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs["aria-labelledby"]);
     const resolvedSize = computed(() => resolveConfigValue(props.size, config.value.size, "middle"));
@@ -198,9 +214,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const requestOpen = (open) => {
       if (isDisabled.value)
         return;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (open)
         setInitialActive();
     };
@@ -220,10 +234,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         });
     };
     const emitValue = (value) => {
-      if (!isControlled.value)
-        internalValue.value = value;
-      emit("update:modelValue", value);
-      emit("change", value);
+      valueState.setState(value, { force: true });
     };
     const clearSearch = () => {
       if (!isSearchControlled.value)
@@ -359,10 +370,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     watch(filteredOptions, () => {
       if (mergedOpen.value)
         setInitialActive();
-    });
-    watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
     });
     const focus = () => {
       var _a;

--- a/packages/components/es/table/table.vue.js
+++ b/packages/components/es/table/table.vue.js
@@ -1,5 +1,7 @@
-import { defineComponent, ref, useId, computed, watch, openBlock, createElementBlock, normalizeClass, createElementVNode, createCommentVNode, Fragment, renderList, normalizeStyle, createVNode, unref, toDisplayString, createBlock } from "vue";
+import { defineComponent, ref, computed, watch, openBlock, createElementBlock, normalizeClass, createElementVNode, createCommentVNode, Fragment, renderList, normalizeStyle, createVNode, unref, toDisplayString, createBlock } from "vue";
 import Pagination from "../pagination/index.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { tableProps, tableEmits } from "./types.js";
 import "./style.css.js";
 import { useAheartConfig, resolveConfigValue } from "../config/context.js";
@@ -30,7 +32,7 @@ const _hoisted_13 = {
   key: 0,
   class: "aheart-table__selection-cell"
 };
-const _hoisted_14 = ["type", "checked", "disabled", "aria-label", "onChange"];
+const _hoisted_14 = ["type", "name", "checked", "disabled", "aria-label", "onChange"];
 const _hoisted_15 = {
   key: 1,
   class: "aheart-table__expand-cell"
@@ -57,7 +59,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
   props: tableProps,
   emits: tableEmits,
   setup(__props, { emit: __emit }) {
-    var _a, _b;
     const ARenderNode = defineComponent({
       name: "ATableRenderNode",
       props: {
@@ -73,55 +74,76 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const props = __props;
     const emit = __emit;
     const config = useAheartConfig();
-    const innerSelectedRowKeys = ref(((_a = props.rowSelection) == null ? void 0 : _a.defaultSelectedRowKeys) ?? []);
-    const innerExpandedRowKeys = ref(((_b = props.expandable) == null ? void 0 : _b.defaultExpandedRowKeys) ?? []);
-    const innerCurrent = ref(props.pagination && typeof props.pagination === "object" ? props.pagination.defaultCurrent ?? props.pagination.current ?? 1 : 1);
+    const hasOwn = (value, key) => Boolean(value && Object.prototype.hasOwnProperty.call(value, key));
+    const selectedState = useControllableState({
+      controlled: () => {
+        var _a;
+        return (_a = props.rowSelection) == null ? void 0 : _a.selectedRowKeys;
+      },
+      isControlled: () => hasOwn(props.rowSelection, "selectedRowKeys"),
+      defaultValue: () => {
+        var _a;
+        return [...((_a = props.rowSelection) == null ? void 0 : _a.defaultSelectedRowKeys) ?? []];
+      },
+      onChange: (keys) => emit("update:selectedRowKeys", keys ?? [])
+    });
+    const expandedState = useControllableState({
+      controlled: () => {
+        var _a;
+        return (_a = props.expandable) == null ? void 0 : _a.expandedRowKeys;
+      },
+      isControlled: () => hasOwn(props.expandable, "expandedRowKeys"),
+      defaultValue: () => {
+        var _a;
+        return [...((_a = props.expandable) == null ? void 0 : _a.defaultExpandedRowKeys) ?? []];
+      },
+      onChange: (keys) => emit("update:expandedRowKeys", keys ?? [])
+    });
+    const currentState = useControllableState({
+      controlled: () => props.pagination && typeof props.pagination === "object" ? props.pagination.current : void 0,
+      isControlled: () => Boolean(props.pagination && typeof props.pagination === "object" && hasOwn(props.pagination, "current")),
+      defaultValue: () => props.pagination && typeof props.pagination === "object" ? props.pagination.defaultCurrent ?? props.pagination.current ?? 1 : 1
+    });
     const innerSort = ref({});
     const innerFilters = ref({});
     const hasInitializedSort = ref(false);
     const initializedFilterKeys = ref(/* @__PURE__ */ new Set());
-    const radioName = `aheart-table-selection-${useId().replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+    const radioName = useStableId(void 0, "aheart-table-selection").value;
     const normalizedColumns = computed(() => (props.columns ?? []).filter((column) => !column.hidden));
     const normalizedData = computed(() => props.dataSource ?? []);
     const resolvedSize = computed(() => resolveConfigValue(props.size, config.value.size, "middle"));
     const isDisabled = computed(() => resolveConfigValue(props.disabled, config.value.disabled, false));
     const hasSelection = computed(() => Boolean(props.rowSelection));
     const hasExpandable = computed(() => {
-      var _a2;
-      return Boolean((_a2 = props.expandable) == null ? void 0 : _a2.expandedRowRender);
+      var _a;
+      return Boolean((_a = props.expandable) == null ? void 0 : _a.expandedRowRender);
     });
     const selectionType = computed(() => {
-      var _a2;
-      return ((_a2 = props.rowSelection) == null ? void 0 : _a2.type) ?? "checkbox";
+      var _a;
+      return ((_a = props.rowSelection) == null ? void 0 : _a.type) ?? "checkbox";
     });
     const isSelectionDisabled = computed(() => {
-      var _a2;
-      return isDisabled.value || Boolean((_a2 = props.rowSelection) == null ? void 0 : _a2.disabled);
+      var _a;
+      return isDisabled.value || Boolean((_a = props.rowSelection) == null ? void 0 : _a.disabled);
     });
-    const selectedKeys = computed(() => {
-      var _a2;
-      return ((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) ?? innerSelectedRowKeys.value;
-    });
-    const expandedKeys = computed(() => {
-      var _a2;
-      return ((_a2 = props.expandable) == null ? void 0 : _a2.expandedRowKeys) ?? innerExpandedRowKeys.value;
-    });
+    const selectedKeys = computed(() => selectedState.state.value ?? []);
+    const expandedKeys = computed(() => expandedState.state.value ?? []);
     const resolvedEmptyText = computed(
       () => {
-        var _a2, _b2, _c, _d;
-        return hasRenderableContent(props.emptyText) ? props.emptyText : ((_b2 = (_a2 = config.value.locale) == null ? void 0 : _a2.table) == null ? void 0 : _b2.emptyText) ?? ((_d = (_c = config.value.locale) == null ? void 0 : _c.empty) == null ? void 0 : _d.description) ?? "No Data";
+        var _a, _b, _c, _d;
+        return hasRenderableContent(props.emptyText) ? props.emptyText : ((_b = (_a = config.value.locale) == null ? void 0 : _a.table) == null ? void 0 : _b.emptyText) ?? ((_d = (_c = config.value.locale) == null ? void 0 : _c.empty) == null ? void 0 : _d.description) ?? "No Data";
       }
     );
     const resolvedLoadingText = computed(() => {
-      var _a2, _b2;
-      return ((_b2 = (_a2 = config.value.locale) == null ? void 0 : _a2.table) == null ? void 0 : _b2.loadingText) ?? "加载中";
+      var _a, _b;
+      return ((_b = (_a = config.value.locale) == null ? void 0 : _a.table) == null ? void 0 : _b.loadingText) ?? "加载中";
     });
     const paginationConfig = computed(() => props.pagination && typeof props.pagination === "object" ? props.pagination : {});
     const pageSize = computed(() => {
       const value = paginationConfig.value.pageSize ?? paginationConfig.value.defaultPageSize ?? 10;
       return Number.isFinite(value) && value > 0 ? Math.max(1, Math.trunc(value)) : 1;
     });
-    const rawCurrentPage = computed(() => paginationConfig.value.current ?? innerCurrent.value);
+    const rawCurrentPage = computed(() => currentState.state.value ?? 1);
     const paginationTotal = computed(() => paginationConfig.value.total ?? sortedData.value.length);
     const pageCount = computed(() => Math.max(1, Math.ceil(Math.max(0, paginationTotal.value) / pageSize.value)));
     const currentPage = computed(() => Math.min(Math.max(rawCurrentPage.value, 1), pageCount.value));
@@ -176,18 +198,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       return allRows.value.slice(start, start + pageSize.value);
     });
     watch(
-      () => {
-        var _a2;
-        return (_a2 = props.rowSelection) == null ? void 0 : _a2.defaultSelectedRowKeys;
-      },
-      (keys) => {
-        var _a2;
-        if (!((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) && keys) {
-          innerSelectedRowKeys.value = keys;
-        }
-      }
-    );
-    watch(
       normalizedColumns,
       (columns) => {
         if (!hasInitializedSort.value) {
@@ -203,13 +213,13 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         const nextFilters = { ...innerFilters.value };
         let shouldUpdateFilters = false;
         columns.forEach((column) => {
-          var _a2;
+          var _a;
           const key = getColumnKey(column);
           if (initializedFilterKeys.value.has(key)) {
             return;
           }
           initializedFilterKeys.value.add(key);
-          if (column.filteredValue === void 0 && ((_a2 = column.defaultFilteredValue) == null ? void 0 : _a2.length)) {
+          if (column.filteredValue === void 0 && ((_a = column.defaultFilteredValue) == null ? void 0 : _a.length)) {
             nextFilters[key] = [...column.defaultFilteredValue];
             shouldUpdateFilters = true;
           }
@@ -221,8 +231,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       { immediate: true }
     );
     watch(pageCount, (count) => {
-      if (paginationConfig.value.current === void 0 && innerCurrent.value > count) {
-        innerCurrent.value = count;
+      if (!currentState.isControlled.value && (currentState.state.value ?? 1) > count) {
+        currentState.setState(count);
       }
     });
     function getColumnKey(column) {
@@ -298,20 +308,20 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       return text === void 0 || text === null ? "" : String(text);
     };
     const renderExpanded = (record, index) => {
-      var _a2, _b2;
-      return ((_b2 = (_a2 = props.expandable) == null ? void 0 : _a2.expandedRowRender) == null ? void 0 : _b2.call(_a2, record, index)) ?? "";
+      var _a, _b;
+      return ((_b = (_a = props.expandable) == null ? void 0 : _a.expandedRowRender) == null ? void 0 : _b.call(_a, record, index)) ?? "";
     };
     const columnStyle = (column) => ({
       width: typeof column.width === "number" ? `${column.width}px` : column.width
     });
     const columnClass = (column) => {
-      var _a2;
+      var _a;
       return [
         column.className,
         column.align ? `aheart-table__cell--${column.align}` : void 0,
         {
           "is-sortable": Boolean(column.sorter),
-          "is-filtered": Boolean((_a2 = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a2.length),
+          "is-filtered": Boolean((_a = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a.length),
           "is-ellipsis": column.ellipsis
         }
       ];
@@ -355,8 +365,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       emitTableChange("sort", 1, pageSize.value, activeFilters.value, nextSort);
     };
     const isFilterActive = (column, value) => {
-      var _a2;
-      return Boolean((_a2 = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a2.includes(value));
+      var _a;
+      return Boolean((_a = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a.includes(value));
     };
     const toggleFilter = (column, value) => {
       if (isDisabled.value) {
@@ -377,45 +387,33 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       emitTableChange("filter", 1, pageSize.value, nextFilters, activeSort.value);
     };
     const resetInnerCurrent = () => {
-      if (paginationConfig.value.current === void 0) {
-        innerCurrent.value = 1;
-      }
+      currentState.setState(1);
     };
     const isSelected = (key) => selectedKeys.value.includes(key);
     const toggleSelection = (record, key, checked) => {
-      var _a2;
       if (isSelectionDisabled.value) {
         return;
       }
       const nextKeys = selectionType.value === "radio" ? checked ? [key] : [] : checked ? Array.from(/* @__PURE__ */ new Set([...selectedKeys.value, key])) : selectedKeys.value.filter((currentKey) => currentKey !== key);
-      if (((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) === void 0) {
-        innerSelectedRowKeys.value = nextKeys;
-      }
-      emit("update:selectedRowKeys", nextKeys);
+      selectedState.setState(nextKeys);
       emit("select", key, checked, record, nextKeys);
     };
     const isRowExpandable = (record) => {
-      var _a2, _b2;
-      return ((_b2 = (_a2 = props.expandable) == null ? void 0 : _a2.rowExpandable) == null ? void 0 : _b2.call(_a2, record)) ?? true;
+      var _a, _b;
+      return ((_b = (_a = props.expandable) == null ? void 0 : _a.rowExpandable) == null ? void 0 : _b.call(_a, record)) ?? true;
     };
     const isExpanded = (key) => expandedKeys.value.includes(key);
     const toggleExpand = (record, key) => {
-      var _a2;
       if (isDisabled.value) {
         return;
       }
       const nextExpanded = !isExpanded(key);
       const nextKeys = nextExpanded ? [...expandedKeys.value, key] : expandedKeys.value.filter((currentKey) => currentKey !== key);
-      if (((_a2 = props.expandable) == null ? void 0 : _a2.expandedRowKeys) === void 0) {
-        innerExpandedRowKeys.value = nextKeys;
-      }
-      emit("update:expandedRowKeys", nextKeys);
+      expandedState.setState(nextKeys);
       emit("expand", nextExpanded, record, key);
     };
     const handlePageChange = (current, nextPageSize) => {
-      if (paginationConfig.value.current === void 0) {
-        innerCurrent.value = current;
-      }
+      currentState.setState(current);
       emitTableChange("paginate", current, nextPageSize, activeFilters.value, activeSort.value);
     };
     const emitTableChange = (action, current, nextPageSize, filters, sortState) => {
@@ -439,14 +437,14 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       );
     };
     const getEventChecked = (event) => {
-      var _a2;
-      return Boolean((_a2 = event.target) == null ? void 0 : _a2.checked);
+      var _a;
+      return Boolean((_a = event.target) == null ? void 0 : _a.checked);
     };
     const handleSelectionChange = (event, record, key) => {
-      var _a2;
+      var _a;
       const input = event.target;
       toggleSelection(record, key, getEventChecked(event));
-      if (input && ((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) !== void 0) {
+      if (input && ((_a = props.rowSelection) == null ? void 0 : _a.selectedRowKeys) !== void 0) {
         input.checked = isSelected(key);
       }
     };
@@ -472,7 +470,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                   }, null, -1)
                 ])])) : createCommentVNode("", true),
                 (openBlock(true), createElementBlock(Fragment, null, renderList(normalizedColumns.value, (column) => {
-                  var _a2;
+                  var _a;
                   return openBlock(), createElementBlock("th", {
                     key: getColumnKey(column),
                     class: normalizeClass(columnClass(column)),
@@ -504,7 +502,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                           node: column.title
                         }, null, 8, ["node"])
                       ])),
-                      ((_a2 = column.filters) == null ? void 0 : _a2.length) ? (openBlock(), createElementBlock("div", {
+                      ((_a = column.filters) == null ? void 0 : _a.length) ? (openBlock(), createElementBlock("div", {
                         key: 2,
                         class: "aheart-table__filters",
                         "aria-label": `${column.title} filters`
@@ -540,7 +538,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                     hasSelection.value ? (openBlock(), createElementBlock("td", _hoisted_13, [
                       createElementVNode("input", {
                         type: selectionType.value,
-                        name: radioName,
+                        name: unref(radioName),
                         checked: isSelected(row.key),
                         disabled: isSelectionDisabled.value,
                         "aria-label": `Select row ${row.key}`,

--- a/packages/components/es/time-picker/time-picker.vue.js
+++ b/packages/components/es/time-picker/time-picker.vue.js
@@ -1,10 +1,12 @@
-import { defineComponent, useAttrs, useSlots, ref, useId, isVNode, h, toRaw, computed, onBeforeUnmount, watch, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, createBlock, Teleport, withDirectives, normalizeStyle, withModifiers, Fragment, renderList, toDisplayString, vShow } from "vue";
+import { defineComponent, useAttrs, useSlots, ref, isVNode, h, toRaw, computed, onBeforeUnmount, watch, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, createBlock, Teleport, withDirectives, normalizeStyle, withModifiers, Fragment, renderList, toDisplayString, vShow } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import { createTimeOptions, parseTimeValue, formatTimeValue } from "../picker-core/time.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import { timePickerProps, timePickerEmits } from "./types.js";
 import "./style.css.js";
@@ -55,13 +57,23 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const secondColumnRef = ref(null);
     const periodColumnRef = ref(null);
     const activeColumn = ref("hour");
-    const internalValue = ref(props.defaultValue);
-    const internalOpen = ref(props.defaultOpen);
-    const instanceId = useId().replace(/:/g, "");
-    const panelId = `aheart-time-${instanceId}-panel`;
+    const instanceId = useStableId(void 0, "aheart-time").value;
+    const panelId = `${instanceId}-panel`;
     const isValueControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
     const isFormatProvided = usePropPresence("format");
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = defineComponent({
       name: "ATimePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -73,8 +85,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         };
       }
     });
-    const mergedValue = computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = computed(() => Boolean(openState.state.value));
     const resolvedLocale = computed(() => {
       var _a;
       return { ...zhCN.timePicker, ...(_a = config.value.locale) == null ? void 0 : _a.timePicker };
@@ -209,9 +221,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const requestOpen = (open) => {
       if (open && isInteractionDisabled.value)
         return;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (open) {
         syncDraft();
         activeColumn.value = "hour";
@@ -221,9 +231,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       if (isInteractionDisabled.value || isPartsDisabled(parts))
         return false;
       const value = formatTime(parts, props.valueFormat);
-      if (!isValueControlled.value)
-        internalValue.value = value;
-      emit("update:modelValue", value);
+      valueState.setState(value, { force: true });
       emit("change", value);
       if (isValueControlled.value && !props.needConfirm)
         syncDraft();
@@ -280,9 +288,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const clearValue = () => {
       if (isInteractionDisabled.value)
         return;
-      if (!isValueControlled.value)
-        internalValue.value = void 0;
-      emit("update:modelValue", void 0);
+      valueState.setState(void 0, { force: true });
       emit("change", void 0);
       emit("clear");
       requestOpen(false);
@@ -391,10 +397,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       if (open)
         void nextTick(scrollSelectedOptionsIntoView);
     }, { immediate: true });
-    watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-    });
     return (_ctx, _cache) => {
       return openBlock(), createElementBlock("span", {
         ref_key: "rootRef",

--- a/packages/components/es/time-picker/time-range-picker.vue.js
+++ b/packages/components/es/time-picker/time-range-picker.vue.js
@@ -1,10 +1,12 @@
-import { defineComponent, useSlots, ref, useId, isVNode, h, toRaw, computed, watch, onBeforeUnmount, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, withModifiers, createBlock, Teleport, withDirectives, normalizeStyle, Fragment, renderList, toDisplayString, vShow } from "vue";
+import { defineComponent, useSlots, ref, isVNode, h, toRaw, computed, watch, onBeforeUnmount, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, createVNode, unref, createCommentVNode, withModifiers, createBlock, Teleport, withDirectives, normalizeStyle, Fragment, renderList, toDisplayString, vShow } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import { createTimeOptions, formatTimeValue, parseTimeValue, timePartsToSeconds } from "../picker-core/time.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import { timeRangePickerProps, timeRangePickerEmits } from "./types.js";
 import "./style.css.js";
@@ -70,14 +72,12 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const minuteColumnRef = ref(null);
     const secondColumnRef = ref(null);
     const periodColumnRef = ref(null);
-    const internalValue = ref(props.defaultValue ? [...props.defaultValue] : void 0);
-    const internalOpen = ref(props.defaultOpen);
     const activePart = ref("start");
     const activeColumn = ref("hour");
     const draftValue = ref();
     const draftParts = ref([{ hour: 0, minute: 0, second: 0 }, { hour: 0, minute: 0, second: 0 }]);
     const liveMessage = ref("");
-    const panelId = `aheart-time-range-${useId().replace(/:/g, "")}-panel`;
+    const panelId = `${useStableId(void 0, "aheart-time-range").value}-panel`;
     const instanceId = panelId.replace("-panel", "");
     const partPanelId = `${instanceId}-part-panel`;
     const startTabId = `${instanceId}-start-tab`;
@@ -85,6 +85,18 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const isValueControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
     const isFormatProvided = usePropPresence("format");
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue ? [...props.defaultValue] : void 0,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = defineComponent({
       name: "ATimeRangePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -96,8 +108,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         };
       }
     });
-    const mergedValue = computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = computed(() => Boolean(openState.state.value));
     const resolvedLocale = computed(() => {
       var _a;
       return { ...zhCN.timePicker, ...(_a = config.value.locale) == null ? void 0 : _a.timePicker };
@@ -268,9 +280,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       if (isInteractionDisabled.value)
         return false;
       if (!value) {
-        if (!isValueControlled.value)
-          internalValue.value = void 0;
-        emit("update:modelValue", void 0);
+        valueState.setState(void 0, { force: true });
         emit("change", void 0);
         if (close)
           requestOpen(false);
@@ -284,9 +294,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         if (parts && isPartsDisabled(parts, index === 0 ? "start" : "end"))
           return false;
       }
-      if (!isValueControlled.value)
-        internalValue.value = [...normalized];
-      emit("update:modelValue", normalized);
+      valueState.setState([...normalized], { force: true });
       emit("change", normalized);
       if (isValueControlled.value && !props.needConfirm)
         syncDraft();
@@ -405,9 +413,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       if (open && isInteractionDisabled.value)
         return;
       const wasOpen = mergedOpen.value;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (open && !wasOpen)
         syncDraft();
     };

--- a/packages/components/es/tree-select/tree-select.vue.js
+++ b/packages/components/es/tree-select/tree-select.vue.js
@@ -1,10 +1,11 @@
-import { defineComponent, useAttrs, ref, computed, watch, openBlock, createElementBlock, normalizeClass, createElementVNode, Fragment, renderList, toDisplayString, withModifiers, createVNode, createCommentVNode, createBlock, Teleport, unref, withDirectives, normalizeStyle, vModelText, vShow, nextTick } from "vue";
+import { defineComponent, useAttrs, ref, computed, openBlock, createElementBlock, normalizeClass, createElementVNode, Fragment, renderList, toDisplayString, withModifiers, createVNode, createCommentVNode, createBlock, Teleport, unref, withDirectives, normalizeStyle, vModelText, vShow, nextTick } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import Tree from "../tree/index.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
+import { useControllableState } from "../utils/use-controllable-state.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import "./style.css.js";
 const _hoisted_1 = ["id", "tabindex", "aria-expanded", "aria-disabled", "aria-labelledby"];
@@ -53,14 +54,30 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const rootRef = ref(null);
     const triggerRef = ref(null);
     const panelRef = ref(null);
-    const innerOpen = ref(props.defaultOpen);
     const searchText = ref("");
-    const innerValue = ref(props.defaultValue);
     const isControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
-    const mergedOpen = computed(() => isOpenControlled.value ? props.open : innerOpen.value);
     const resolvedAriaLabelledby = computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs["aria-labelledby"]);
-    const mergedValue = computed(() => isControlled.value ? props.modelValue : innerValue.value);
+    const openState = useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => {
+        const nextOpen = Boolean(open);
+        emit("openChange", nextOpen);
+      }
+    });
+    const valueState = useControllableState({
+      controlled: () => props.modelValue,
+      isControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => {
+        emit("update:modelValue", value);
+        emit("change", value);
+      }
+    });
+    const mergedOpen = computed(() => Boolean(openState.state.value));
+    const mergedValue = valueState.state;
     const selectedKeys = computed(() => Array.isArray(mergedValue.value) ? mergedValue.value : mergedValue.value === void 0 ? [] : [mergedValue.value]);
     const flattenNodes = (nodes) => nodes.flatMap((node) => [node, ...flattenNodes(node.children ?? [])]);
     const displayLabel = computed(() => selectedKeys.value.map((key) => {
@@ -96,15 +113,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const requestOpen = (open) => {
       if (props.disabled)
         return;
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
     };
     const emitValue = (value) => {
-      if (!isControlled.value)
-        innerValue.value = value;
-      emit("update:modelValue", value);
-      emit("change", value);
+      valueState.setState(value, { force: true });
     };
     const handleSelect = (keys) => {
       const value = props.multiple ? keys : keys[0];
@@ -173,10 +185,6 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       trigger: triggerRef,
       floating: panelRef,
       onDismiss: () => requestOpen(false)
-    });
-    watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
     });
     return (_ctx, _cache) => {
       return openBlock(), createElementBlock("div", {

--- a/packages/components/es/upload/upload.vue.js
+++ b/packages/components/es/upload/upload.vue.js
@@ -1,4 +1,6 @@
 import { defineComponent, computed, ref, watch, openBlock, createElementBlock, normalizeClass, createElementVNode, renderSlot, toDisplayString, createCommentVNode, Fragment, renderList } from "vue";
+import { useControllableState } from "../utils/use-controllable-state.js";
+import { usePropPresence } from "../utils/use-prop-presence.js";
 import "./style.css.js";
 import { useAheartConfig } from "../config/context.js";
 const _hoisted_1 = { class: "aheart-upload__trigger" };
@@ -33,21 +35,25 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       var _a, _b;
       return ((_b = (_a = config.value.locale) == null ? void 0 : _a.datePicker) == null ? void 0 : _b.locale) === "en-US" ? { selectFile: "Select file", upload: "Upload", done: "Done", failed: "Failed", removeAction: "Remove", remove: (name) => `Remove ${name}` } : { selectFile: "选择文件", upload: "上传", done: "已完成", failed: "上传失败", removeAction: "移除", remove: (name) => `移除 ${name}` };
     });
-    const internalFileList = ref([...props.defaultFileList]);
-    const mergedFileList = computed(() => props.fileList ?? internalFileList.value);
+    const isFileListControlled = usePropPresence("fileList", "file-list");
+    const fileListState = useControllableState({
+      controlled: () => props.fileList,
+      isControlled: isFileListControlled,
+      defaultValue: () => [...props.defaultFileList],
+      onChange: (files) => emit("update:fileList", files ?? [])
+    });
+    const mergedFileList = computed(() => fileListState.state.value ?? []);
     const readyFiles = computed(() => mergedFileList.value.filter((file) => file.status === "ready"));
     const latestFileList = ref([...props.fileList ?? props.defaultFileList]);
     let uid = 0;
     const activeUploadUids = /* @__PURE__ */ new Set();
     watch(() => props.fileList, (fileList) => {
-      if (fileList !== void 0)
-        latestFileList.value = [...fileList];
+      if (isFileListControlled.value)
+        latestFileList.value = [...fileList ?? []];
     }, { deep: true });
     const updateFileList = (files) => {
       latestFileList.value = files;
-      if (props.fileList === void 0)
-        internalFileList.value = files;
-      emit("update:fileList", files);
+      fileListState.setState(files);
       emit("change", files);
     };
     const replaceFile = (file) => {
@@ -106,13 +112,17 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         return;
       const files = Array.from(event.target.files ?? []);
       event.target.value = "";
-      let nextFiles = props.fileList === void 0 ? latestFileList.value : [...props.fileList];
+      let nextFiles = isFileListControlled.value ? [...props.fileList ?? []] : latestFileList.value;
       latestFileList.value = nextFiles;
-      const remaining = Math.max(0, props.maxCount - nextFiles.length);
-      for (const rawFile of files.slice(0, remaining)) {
+      for (const rawFile of files) {
+        if (nextFiles.length >= props.maxCount)
+          break;
         const uploadFile = toUploadFile(rawFile);
         const shouldUpload = await ((_a = props.beforeUpload) == null ? void 0 : _a.call(props, rawFile, [...nextFiles, uploadFile]));
-        nextFiles = [...nextFiles, uploadFile];
+        const currentFiles = isFileListControlled.value ? [...props.fileList ?? []] : latestFileList.value;
+        if (currentFiles.length >= props.maxCount)
+          continue;
+        nextFiles = [...currentFiles, uploadFile];
         updateFileList(nextFiles);
         if (shouldUpload !== false)
           nextFiles = await upload(uploadFile, nextFiles);

--- a/packages/components/es/utils/use-async-task.d.ts
+++ b/packages/components/es/utils/use-async-task.d.ts
@@ -1,0 +1,18 @@
+export type AsyncTaskStatus = 'idle' | 'pending' | 'success' | 'error';
+export interface AsyncTaskContext {
+    signal: AbortSignal;
+    requestId: number;
+}
+export interface AsyncTaskOptions<TResult> {
+    onSuccess?: (result: TResult) => void;
+    onError?: (error: unknown) => void;
+}
+export declare const useAsyncTask: <TArgs extends unknown[], TResult>(task: (context: AsyncTaskContext, ...args: TArgs) => Promise<TResult>, options?: AsyncTaskOptions<TResult>) => {
+    status: Readonly<import("vue").Ref<AsyncTaskStatus, AsyncTaskStatus>>;
+    data: Readonly<import("vue").Ref<import("vue").DeepReadonly<TResult> | undefined, import("vue").DeepReadonly<TResult> | undefined>>;
+    error: Readonly<import("vue").Ref<Readonly<unknown>, Readonly<unknown>>>;
+    isPending: import("vue").ComputedRef<boolean>;
+    run: (...args: TArgs) => Promise<TResult | undefined>;
+    abort: () => void;
+    reset: () => void;
+};

--- a/packages/components/es/utils/use-async-task.js
+++ b/packages/components/es/utils/use-async-task.js
@@ -1,0 +1,61 @@
+import { shallowRef, onBeforeUnmount, readonly, computed } from "vue";
+const useAsyncTask = (task, options = {}) => {
+  const status = shallowRef("idle");
+  const data = shallowRef();
+  const error = shallowRef();
+  let requestId = 0;
+  let controller;
+  const abort = () => {
+    requestId += 1;
+    controller == null ? void 0 : controller.abort();
+    controller = void 0;
+    if (status.value === "pending")
+      status.value = "idle";
+  };
+  const reset = () => {
+    abort();
+    status.value = "idle";
+    data.value = void 0;
+    error.value = void 0;
+  };
+  const run = async (...args) => {
+    var _a, _b;
+    controller == null ? void 0 : controller.abort();
+    const currentController = new AbortController();
+    const currentRequestId = ++requestId;
+    controller = currentController;
+    status.value = "pending";
+    error.value = void 0;
+    try {
+      const result = await task({ signal: currentController.signal, requestId: currentRequestId }, ...args);
+      if (currentController.signal.aborted || currentRequestId !== requestId)
+        return void 0;
+      controller = void 0;
+      data.value = result;
+      status.value = "success";
+      (_a = options.onSuccess) == null ? void 0 : _a.call(options, result);
+      return result;
+    } catch (reason) {
+      if (currentController.signal.aborted || currentRequestId !== requestId)
+        return void 0;
+      controller = void 0;
+      error.value = reason;
+      status.value = "error";
+      (_b = options.onError) == null ? void 0 : _b.call(options, reason);
+      return void 0;
+    }
+  };
+  onBeforeUnmount(abort);
+  return {
+    status: readonly(status),
+    data: readonly(data),
+    error: readonly(error),
+    isPending: computed(() => status.value === "pending"),
+    run,
+    abort,
+    reset
+  };
+};
+export {
+  useAsyncTask
+};

--- a/packages/components/es/utils/use-collection.d.ts
+++ b/packages/components/es/utils/use-collection.d.ts
@@ -1,0 +1,30 @@
+import { type Ref } from 'vue';
+export interface CollectionItem<T extends HTMLElement = HTMLElement> {
+    key: string;
+    element: T;
+    disabled: boolean;
+    visible: boolean;
+}
+export interface CollectionRegistration<T extends HTMLElement = HTMLElement> {
+    key?: string;
+    element: T;
+    disabled?: boolean;
+    visible?: boolean;
+}
+export interface UseCollectionReturn<T extends HTMLElement = HTMLElement> {
+    items: Ref<CollectionItem<T>[]>;
+    register: (item: CollectionRegistration<T>) => {
+        key: string;
+        unregister: () => void;
+    };
+    unregister: (key: string) => void;
+    update: (key: string, patch: Partial<Pick<CollectionItem<T>, 'element' | 'disabled' | 'visible'>>) => void;
+    getItem: (key: string) => CollectionItem<T> | undefined;
+    getItems: () => CollectionItem<T>[];
+    getVisibleItems: () => CollectionItem<T>[];
+    getEnabledItems: () => CollectionItem<T>[];
+    isVisible: (key: string) => boolean;
+    isDisabled: (key: string) => boolean;
+}
+/** Internal ordered registry shared by composite components. */
+export declare function useCollection<T extends HTMLElement = HTMLElement>(): UseCollectionReturn<T>;

--- a/packages/components/es/utils/use-collection.js
+++ b/packages/components/es/utils/use-collection.js
@@ -1,0 +1,51 @@
+import { shallowRef } from "vue";
+function useCollection() {
+  const items = shallowRef([]);
+  let nextKey = 0;
+  const makeKey = () => `collection-item-${++nextKey}`;
+  const getItem = (key) => items.value.find((item) => item.key === key);
+  const getItems = () => items.value.slice();
+  const getVisibleItems = () => items.value.filter((item) => item.visible);
+  const getEnabledItems = () => items.value.filter((item) => item.visible && !item.disabled);
+  const unregister = (key) => {
+    const index = items.value.findIndex((item) => item.key === key);
+    if (index >= 0)
+      items.value = items.value.filter((item) => item.key !== key);
+  };
+  const register = (input) => {
+    const key = input.key || makeKey();
+    const existing = getItem(key);
+    if (existing) {
+      items.value = items.value.map((item) => item.key === key ? { ...item, element: input.element, disabled: !!input.disabled, visible: input.visible !== false } : item);
+    } else {
+      items.value = [...items.value, { key, element: input.element, disabled: !!input.disabled, visible: input.visible !== false }];
+    }
+    return { key, unregister: () => unregister(key) };
+  };
+  const update = (key, patch) => {
+    const item = getItem(key);
+    if (item)
+      items.value = items.value.map((entry) => entry.key === key ? { ...entry, ...patch } : entry);
+  };
+  return {
+    items,
+    register,
+    unregister,
+    update,
+    getItem,
+    getItems,
+    getVisibleItems,
+    getEnabledItems,
+    isVisible: (key) => {
+      var _a;
+      return ((_a = getItem(key)) == null ? void 0 : _a.visible) === true;
+    },
+    isDisabled: (key) => {
+      var _a;
+      return ((_a = getItem(key)) == null ? void 0 : _a.disabled) === true;
+    }
+  };
+}
+export {
+  useCollection
+};

--- a/packages/components/es/utils/use-controllable-state.d.ts
+++ b/packages/components/es/utils/use-controllable-state.d.ts
@@ -1,0 +1,22 @@
+import { type MaybeRefOrGetter, type Ref } from 'vue';
+export interface UseControllableStateOptions<T> {
+    /** Presence of this property opts into controlled mode, including an undefined value. */
+    controlled?: MaybeRefOrGetter<T | undefined>;
+    /** Overrides property-presence detection when controlledness changes at runtime. */
+    isControlled?: MaybeRefOrGetter<boolean>;
+    defaultValue?: MaybeRefOrGetter<T | undefined>;
+    onChange?: (value: T | undefined) => void;
+}
+export interface UseControllableStateReturn<T> {
+    state: Readonly<Ref<T | undefined>>;
+    isControlled: Readonly<Ref<boolean>>;
+    setState: (next: T | undefined | ((current: T | undefined) => T | undefined), options?: {
+        force?: boolean;
+    }) => boolean;
+}
+/**
+ * Small internal state bridge for controls that support both v-model and defaults.
+ * Controlled state is always read from its owner, so rejected update events cannot
+ * leave an optimistic value behind.
+ */
+export declare const useControllableState: <T>(options: UseControllableStateOptions<T>) => UseControllableStateReturn<T>;

--- a/packages/components/es/utils/use-controllable-state.js
+++ b/packages/components/es/utils/use-controllable-state.js
@@ -1,0 +1,31 @@
+import { computed, toValue, ref, watch } from "vue";
+const useControllableState = (options) => {
+  const controlledByPresence = Object.prototype.hasOwnProperty.call(options, "controlled");
+  const isControlled = computed(() => options.isControlled === void 0 ? controlledByPresence : toValue(options.isControlled));
+  const uncontrolled = ref(toValue(options.defaultValue));
+  const state = computed(() => isControlled.value ? toValue(options.controlled) : uncontrolled.value);
+  watch(
+    [isControlled, () => toValue(options.controlled)],
+    ([controlled, value]) => {
+      if (controlled)
+        uncontrolled.value = value;
+    },
+    { flush: "sync", immediate: true }
+  );
+  const setState = (next, setOptions = {}) => {
+    var _a;
+    const value = typeof next === "function" ? next(state.value) : next;
+    if (!setOptions.force && Object.is(value, state.value)) {
+      return false;
+    }
+    if (!isControlled.value) {
+      uncontrolled.value = value;
+    }
+    (_a = options.onChange) == null ? void 0 : _a.call(options, value);
+    return true;
+  };
+  return { state, isControlled, setState };
+};
+export {
+  useControllableState
+};

--- a/packages/components/es/utils/use-roving-focus.d.ts
+++ b/packages/components/es/utils/use-roving-focus.d.ts
@@ -1,0 +1,14 @@
+import { type MaybeRefOrGetter } from 'vue';
+import type { UseCollectionReturn } from './use-collection';
+export type RovingOrientation = 'horizontal' | 'vertical' | 'both';
+export interface UseRovingFocusOptions<T extends HTMLElement = HTMLElement> {
+    collection: UseCollectionReturn<T> | MaybeRefOrGetter<UseCollectionReturn<T>>;
+    orientation?: RovingOrientation | MaybeRefOrGetter<RovingOrientation>;
+    loop?: boolean | MaybeRefOrGetter<boolean>;
+    preventDefault?: boolean | MaybeRefOrGetter<boolean>;
+}
+export declare function useRovingFocus<T extends HTMLElement = HTMLElement>(options: UseRovingFocusOptions<T>): {
+    getNextKey: (currentKey: string | undefined, key: string) => string | undefined;
+    focus: (key: string, preventScroll?: boolean) => boolean;
+    onKeydown: (event: KeyboardEvent, currentKey?: string) => boolean;
+};

--- a/packages/components/es/utils/use-roving-focus.js
+++ b/packages/components/es/utils/use-roving-focus.js
@@ -1,0 +1,50 @@
+import { toValue } from "vue";
+function useRovingFocus(options) {
+  const collection = () => toValue(options.collection);
+  const orientation = () => toValue(options.orientation) ?? "both";
+  const loops = () => toValue(options.loop) !== false;
+  const shouldPrevent = () => toValue(options.preventDefault) !== false;
+  const isDirection = (key) => {
+    if (orientation() === "horizontal")
+      return key === "ArrowLeft" || key === "ArrowRight";
+    if (orientation() === "vertical")
+      return key === "ArrowUp" || key === "ArrowDown";
+    return key.startsWith("Arrow");
+  };
+  const getNextKey = (currentKey, key) => {
+    const entries = collection().getEnabledItems();
+    if (!entries.length || key !== "Home" && key !== "End" && !isDirection(key))
+      return void 0;
+    if (key === "Home")
+      return entries[0].key;
+    if (key === "End")
+      return entries[entries.length - 1].key;
+    const forward = key === "ArrowRight" || key === "ArrowDown";
+    const index = entries.findIndex((item) => item.key === currentKey);
+    if (index < 0)
+      return forward ? entries[0].key : entries[entries.length - 1].key;
+    const next = index + (forward ? 1 : -1);
+    if (next >= 0 && next < entries.length)
+      return entries[next].key;
+    return loops() ? entries[(next + entries.length) % entries.length].key : void 0;
+  };
+  const focus = (key, preventScroll = true) => {
+    const item = collection().getItem(key);
+    if (!item || !item.visible || item.disabled)
+      return false;
+    item.element.focus({ preventScroll });
+    return true;
+  };
+  const onKeydown = (event, currentKey) => {
+    const nextKey = getNextKey(currentKey, event.key);
+    if (!nextKey)
+      return false;
+    if (shouldPrevent())
+      event.preventDefault();
+    return focus(nextKey);
+  };
+  return { getNextKey, focus, onKeydown };
+}
+export {
+  useRovingFocus
+};

--- a/packages/components/es/utils/use-stable-id.d.ts
+++ b/packages/components/es/utils/use-stable-id.d.ts
@@ -1,0 +1,3 @@
+import { type MaybeRefOrGetter, type ComputedRef } from 'vue';
+/** Returns an explicit id when supplied, otherwise a Vue SSR-safe generated id. */
+export declare const useStableId: (explicitId?: MaybeRefOrGetter<string | undefined>, prefix?: string) => ComputedRef<string>;

--- a/packages/components/es/utils/use-stable-id.js
+++ b/packages/components/es/utils/use-stable-id.js
@@ -1,0 +1,8 @@
+import { useId, computed, toValue } from "vue";
+const useStableId = (explicitId, prefix = "aheart") => {
+  const generatedId = `${prefix}-${useId().replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  return computed(() => toValue(explicitId) ?? generatedId);
+};
+export {
+  useStableId
+};

--- a/packages/components/lib/cascader/cascader.vue.js
+++ b/packages/components/lib/cascader/cascader.vue.js
@@ -6,6 +6,7 @@ const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 require("./style.css.js");
 const _hoisted_1 = ["tabindex", "aria-expanded", "aria-disabled"];
@@ -62,16 +63,32 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const triggerRef = vue.ref(null);
     const panelRef = vue.ref(null);
     const columnsRef = vue.ref(null);
-    const innerOpen = vue.ref(props.defaultOpen);
     const searchText = vue.ref("");
     const activePath = vue.ref([]);
     const loadingPaths = vue.ref([]);
     const innerOptions = vue.ref(cloneOptions(props.options));
-    const innerValue = vue.ref(props.defaultValue);
     const isControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
-    const mergedOpen = vue.computed(() => isOpenControlled.value ? props.open : innerOpen.value);
-    const mergedValue = vue.computed(() => isControlled.value ? props.modelValue : innerValue.value);
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => {
+        const nextOpen = Boolean(open);
+        emit("openChange", nextOpen);
+      }
+    });
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => {
+        emit("update:modelValue", value);
+        emit("change", value);
+      }
+    });
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
+    const mergedValue = valueState.state;
     const selectedPaths = vue.computed(() => {
       if (props.multiple) {
         return Array.isArray(mergedValue.value) && mergedValue.value.every(Array.isArray) ? mergedValue.value : [];
@@ -155,16 +172,11 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const requestOpen = (open) => {
       if (props.disabled)
         return;
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
     };
     const toggleOpen = () => requestOpen(!mergedOpen.value);
     const emitValue = (value) => {
-      if (!isControlled.value)
-        innerValue.value = value;
-      emit("update:modelValue", value);
-      emit("change", value);
+      valueState.setState(value, { force: true });
     };
     const clearValue = () => {
       emitValue(props.multiple ? [] : void 0);
@@ -288,10 +300,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       trigger: triggerRef,
       floating: panelRef,
       onDismiss: () => requestOpen(false)
-    });
-    vue.watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
     });
     return (_ctx, _cache) => {
       return vue.openBlock(), vue.createElementBlock("div", {

--- a/packages/components/lib/date-picker/date-picker.vue.js
+++ b/packages/components/lib/date-picker/date-picker.vue.js
@@ -9,7 +9,9 @@ const selection = require("../picker-core/selection.js");
 const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 const types = require("./types.js");
 require("./style.css.js");
@@ -74,17 +76,26 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const triggerRef = vue.ref(null);
     const inputRef = vue.ref(null);
     const panelRef = vue.ref(null);
-    const internalValue = vue.ref(props.defaultValue);
-    const internalOpen = vue.ref(props.defaultOpen);
     const draftValue = vue.ref();
     const inputText = vue.ref("");
     const activeCellKey = vue.ref("");
     const liveMessage = vue.ref("");
-    const instanceId = vue.useId().replace(/:/g, "");
-    const panelId = `aheart-date-picker-${instanceId}-panel`;
+    const panelId = `${useStableId.useStableId(void 0, "aheart-date-picker").value}-panel`;
     const isValueControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
     const isPanelControlled = usePropPresence.usePropPresence("pickerValue", "picker-value");
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = vue.defineComponent({
       name: "ADatePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -96,8 +107,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         };
       }
     });
-    const mergedValue = vue.computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = vue.computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
     const selectedValues = vue.computed(() => Array.isArray(mergedValue.value) ? mergedValue.value : mergedValue.value ? [mergedValue.value] : []);
     const effectiveShowTime = vue.computed(() => Boolean(props.showTime) && !props.multiple && props.picker === "date");
     const showTimeOptions = vue.computed(() => typeof props.showTime === "object" ? props.showTime : {});
@@ -292,9 +303,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         return;
       if (!nextOpen)
         restoreFocusOnClose = restoreFocus;
-      if (!isOpenControlled.value)
-        internalOpen.value = nextOpen;
-      emit("openChange", nextOpen);
+      openState.setState(nextOpen, { force: true });
     };
     let restoringFocus = false;
     const handleFocus = () => {
@@ -332,9 +341,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     });
     const commitValue = (value, close = true) => {
       const normalized = Array.isArray(value) ? selection.normalizeMultipleValues(value) : value;
-      if (!isValueControlled.value)
-        internalValue.value = normalized;
-      emit("update:modelValue", normalized);
+      valueState.setState(normalized, { force: true });
       emit("change", normalized);
       if (isValueControlled.value) {
         void vue.nextTick(() => {

--- a/packages/components/lib/date-picker/date-range-picker.vue.js
+++ b/packages/components/lib/date-picker/date-range-picker.vue.js
@@ -9,7 +9,9 @@ const selection = require("../picker-core/selection.js");
 const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 const types = require("./types.js");
 require("./style.css.js");
@@ -80,8 +82,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const panelRef = vue.ref(null);
     const startInputRef = vue.ref(null);
     const endInputRef = vue.ref(null);
-    const internalValue = vue.ref(props.defaultValue ? [...props.defaultValue] : void 0);
-    const internalOpen = vue.ref(props.defaultOpen);
     const draftValue = vue.ref();
     const activePart = vue.ref("start");
     const activeKeyboardDate = vue.ref();
@@ -91,10 +91,22 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const inputTexts = vue.ref(["", ""]);
     const nowDate = vue.ref();
     const rangeParts = ["start", "end"];
-    const panelId = `aheart-date-range-picker-${vue.useId().replace(/:/g, "")}-panel`;
+    const panelId = `${useStableId.useStableId(void 0, "aheart-date-range-picker").value}-panel`;
     const isValueControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
     const isPanelControlled = usePropPresence.usePropPresence("pickerValue", "picker-value");
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue ? [...props.defaultValue] : void 0,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = vue.defineComponent({
       name: "ADateRangePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -106,8 +118,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         };
       }
     });
-    const mergedValue = vue.computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = vue.computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
     const effectiveShowTime = vue.computed(() => Boolean(props.showTime) && props.picker === "date");
     const showTimeOptions = vue.computed(() => typeof props.showTime === "object" ? props.showTime : {});
     const effectiveNeedConfirm = vue.computed(() => props.needConfirm ?? effectiveShowTime.value);
@@ -313,9 +325,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const requestOpen = (open, restoreFocus = false) => {
       if (open && (isDisabled.value || props.readOnly))
         return;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (!open && restoreFocus)
         void vue.nextTick(() => {
           var _a;
@@ -471,9 +481,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     const commitValue = (value, close = true) => {
       const normalized = selection.normalizeRangeValue(value, resolvedValueFormat.value, props.order, props.allowEmpty) ?? value;
-      if (!isValueControlled.value)
-        internalValue.value = normalized ? [...normalized] : void 0;
-      emit("update:modelValue", normalized);
+      valueState.setState(normalized ? [...normalized] : void 0, { force: true });
       emit("change", normalized);
       if (isValueControlled.value)
         void vue.nextTick(syncInputs);
@@ -671,7 +679,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
               onChange: _cache[2] || (_cache[2] = ($event) => commitInput("start")),
               onKeydown: handleInputKeydown
             }, null, 40, _hoisted_2),
-            _ctx.allowClear && ((_a = mergedValue.value) == null ? void 0 : _a[0]) && _ctx.allowEmpty[0] && !isDisabled.value && !_ctx.readOnly ? (vue.openBlock(), vue.createElementBlock("button", {
+            _ctx.allowClear && ((_a = vue.unref(mergedValue)) == null ? void 0 : _a[0]) && _ctx.allowEmpty[0] && !isDisabled.value && !_ctx.readOnly ? (vue.openBlock(), vue.createElementBlock("button", {
               key: 0,
               "data-range-clear": "start",
               type: "button",
@@ -721,7 +729,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
               onChange: _cache[6] || (_cache[6] = ($event) => commitInput("end")),
               onKeydown: handleInputKeydown
             }, null, 40, _hoisted_5),
-            _ctx.allowClear && ((_b = mergedValue.value) == null ? void 0 : _b[1]) && _ctx.allowEmpty[1] && !isDisabled.value && !_ctx.readOnly ? (vue.openBlock(), vue.createElementBlock("button", {
+            _ctx.allowClear && ((_b = vue.unref(mergedValue)) == null ? void 0 : _b[1]) && _ctx.allowEmpty[1] && !isDisabled.value && !_ctx.readOnly ? (vue.openBlock(), vue.createElementBlock("button", {
               key: 0,
               "data-range-clear": "end",
               type: "button",

--- a/packages/components/lib/select/select.vue.js
+++ b/packages/components/lib/select/select.vue.js
@@ -5,7 +5,9 @@ const icon_vue_vue_type_script_setup_true_lang = require("../icon/icon.vue.js");
 const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 const types = require("./types.js");
 require("./style.css.js");
@@ -48,12 +50,9 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const searchRef = vue.ref(null);
     const popupRef = vue.ref(null);
     const internalSearchValue = vue.ref("");
-    const internalValue = vue.ref(props.defaultValue);
-    const internalOpen = vue.ref(props.defaultOpen);
     const activeIndex = vue.ref(-1);
     const focused = vue.ref(false);
-    const instanceId = vue.useId().replace(/:/g, "");
-    const listboxId = `aheart-select-${instanceId}-listbox`;
+    const listboxId = `${useStableId.useStableId(void 0, "aheart-select").value}-listbox`;
     const ARenderNode = vue.defineComponent({
       name: "ASelectRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -78,10 +77,27 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const isMultiple = vue.computed(() => props.mode === "multiple" || props.mode === "tags");
     const isSearchable = vue.computed(() => props.showSearch || props.mode === "tags");
     const isControlled = usePropPresence.usePropPresence("modelValue", "model-value");
-    const mergedValue = vue.computed(() => isControlled.value ? props.modelValue : internalValue.value);
     const isOpenControlled = usePropPresence.usePropPresence("open");
     const isSearchControlled = usePropPresence.usePropPresence("searchValue", "search-value");
-    const mergedOpen = vue.computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => {
+        if (value === void 0)
+          return;
+        emit("update:modelValue", value);
+        emit("change", value);
+      }
+    });
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
+    const mergedValue = valueState.state;
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
     const currentSearchValue = vue.computed(() => isSearchControlled.value ? props.searchValue ?? "" : internalSearchValue.value);
     const resolvedAriaLabelledby = vue.computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs["aria-labelledby"]);
     const resolvedSize = vue.computed(() => context.resolveConfigValue(props.size, config.value.size, "middle"));
@@ -200,9 +216,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const requestOpen = (open) => {
       if (isDisabled.value)
         return;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (open)
         setInitialActive();
     };
@@ -222,10 +236,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         });
     };
     const emitValue = (value) => {
-      if (!isControlled.value)
-        internalValue.value = value;
-      emit("update:modelValue", value);
-      emit("change", value);
+      valueState.setState(value, { force: true });
     };
     const clearSearch = () => {
       if (!isSearchControlled.value)
@@ -361,10 +372,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     vue.watch(filteredOptions, () => {
       if (mergedOpen.value)
         setInitialActive();
-    });
-    vue.watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
     });
     const focus = () => {
       var _a;

--- a/packages/components/lib/table/table.vue.js
+++ b/packages/components/lib/table/table.vue.js
@@ -2,6 +2,8 @@
 Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: "Module" } });
 const vue = require("vue");
 const index = require("../pagination/index.js");
+const useControllableState = require("../utils/use-controllable-state.js");
+const useStableId = require("../utils/use-stable-id.js");
 const types = require("./types.js");
 require("./style.css.js");
 const context = require("../config/context.js");
@@ -32,7 +34,7 @@ const _hoisted_13 = {
   key: 0,
   class: "aheart-table__selection-cell"
 };
-const _hoisted_14 = ["type", "checked", "disabled", "aria-label", "onChange"];
+const _hoisted_14 = ["type", "name", "checked", "disabled", "aria-label", "onChange"];
 const _hoisted_15 = {
   key: 1,
   class: "aheart-table__expand-cell"
@@ -59,7 +61,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   props: types.tableProps,
   emits: types.tableEmits,
   setup(__props, { emit: __emit }) {
-    var _a, _b;
     const ARenderNode = vue.defineComponent({
       name: "ATableRenderNode",
       props: {
@@ -75,55 +76,76 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const props = __props;
     const emit = __emit;
     const config = context.useAheartConfig();
-    const innerSelectedRowKeys = vue.ref(((_a = props.rowSelection) == null ? void 0 : _a.defaultSelectedRowKeys) ?? []);
-    const innerExpandedRowKeys = vue.ref(((_b = props.expandable) == null ? void 0 : _b.defaultExpandedRowKeys) ?? []);
-    const innerCurrent = vue.ref(props.pagination && typeof props.pagination === "object" ? props.pagination.defaultCurrent ?? props.pagination.current ?? 1 : 1);
+    const hasOwn = (value, key) => Boolean(value && Object.prototype.hasOwnProperty.call(value, key));
+    const selectedState = useControllableState.useControllableState({
+      controlled: () => {
+        var _a;
+        return (_a = props.rowSelection) == null ? void 0 : _a.selectedRowKeys;
+      },
+      isControlled: () => hasOwn(props.rowSelection, "selectedRowKeys"),
+      defaultValue: () => {
+        var _a;
+        return [...((_a = props.rowSelection) == null ? void 0 : _a.defaultSelectedRowKeys) ?? []];
+      },
+      onChange: (keys) => emit("update:selectedRowKeys", keys ?? [])
+    });
+    const expandedState = useControllableState.useControllableState({
+      controlled: () => {
+        var _a;
+        return (_a = props.expandable) == null ? void 0 : _a.expandedRowKeys;
+      },
+      isControlled: () => hasOwn(props.expandable, "expandedRowKeys"),
+      defaultValue: () => {
+        var _a;
+        return [...((_a = props.expandable) == null ? void 0 : _a.defaultExpandedRowKeys) ?? []];
+      },
+      onChange: (keys) => emit("update:expandedRowKeys", keys ?? [])
+    });
+    const currentState = useControllableState.useControllableState({
+      controlled: () => props.pagination && typeof props.pagination === "object" ? props.pagination.current : void 0,
+      isControlled: () => Boolean(props.pagination && typeof props.pagination === "object" && hasOwn(props.pagination, "current")),
+      defaultValue: () => props.pagination && typeof props.pagination === "object" ? props.pagination.defaultCurrent ?? props.pagination.current ?? 1 : 1
+    });
     const innerSort = vue.ref({});
     const innerFilters = vue.ref({});
     const hasInitializedSort = vue.ref(false);
     const initializedFilterKeys = vue.ref(/* @__PURE__ */ new Set());
-    const radioName = `aheart-table-selection-${vue.useId().replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+    const radioName = useStableId.useStableId(void 0, "aheart-table-selection").value;
     const normalizedColumns = vue.computed(() => (props.columns ?? []).filter((column) => !column.hidden));
     const normalizedData = vue.computed(() => props.dataSource ?? []);
     const resolvedSize = vue.computed(() => context.resolveConfigValue(props.size, config.value.size, "middle"));
     const isDisabled = vue.computed(() => context.resolveConfigValue(props.disabled, config.value.disabled, false));
     const hasSelection = vue.computed(() => Boolean(props.rowSelection));
     const hasExpandable = vue.computed(() => {
-      var _a2;
-      return Boolean((_a2 = props.expandable) == null ? void 0 : _a2.expandedRowRender);
+      var _a;
+      return Boolean((_a = props.expandable) == null ? void 0 : _a.expandedRowRender);
     });
     const selectionType = vue.computed(() => {
-      var _a2;
-      return ((_a2 = props.rowSelection) == null ? void 0 : _a2.type) ?? "checkbox";
+      var _a;
+      return ((_a = props.rowSelection) == null ? void 0 : _a.type) ?? "checkbox";
     });
     const isSelectionDisabled = vue.computed(() => {
-      var _a2;
-      return isDisabled.value || Boolean((_a2 = props.rowSelection) == null ? void 0 : _a2.disabled);
+      var _a;
+      return isDisabled.value || Boolean((_a = props.rowSelection) == null ? void 0 : _a.disabled);
     });
-    const selectedKeys = vue.computed(() => {
-      var _a2;
-      return ((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) ?? innerSelectedRowKeys.value;
-    });
-    const expandedKeys = vue.computed(() => {
-      var _a2;
-      return ((_a2 = props.expandable) == null ? void 0 : _a2.expandedRowKeys) ?? innerExpandedRowKeys.value;
-    });
+    const selectedKeys = vue.computed(() => selectedState.state.value ?? []);
+    const expandedKeys = vue.computed(() => expandedState.state.value ?? []);
     const resolvedEmptyText = vue.computed(
       () => {
-        var _a2, _b2, _c, _d;
-        return hasRenderableContent(props.emptyText) ? props.emptyText : ((_b2 = (_a2 = config.value.locale) == null ? void 0 : _a2.table) == null ? void 0 : _b2.emptyText) ?? ((_d = (_c = config.value.locale) == null ? void 0 : _c.empty) == null ? void 0 : _d.description) ?? "No Data";
+        var _a, _b, _c, _d;
+        return hasRenderableContent(props.emptyText) ? props.emptyText : ((_b = (_a = config.value.locale) == null ? void 0 : _a.table) == null ? void 0 : _b.emptyText) ?? ((_d = (_c = config.value.locale) == null ? void 0 : _c.empty) == null ? void 0 : _d.description) ?? "No Data";
       }
     );
     const resolvedLoadingText = vue.computed(() => {
-      var _a2, _b2;
-      return ((_b2 = (_a2 = config.value.locale) == null ? void 0 : _a2.table) == null ? void 0 : _b2.loadingText) ?? "加载中";
+      var _a, _b;
+      return ((_b = (_a = config.value.locale) == null ? void 0 : _a.table) == null ? void 0 : _b.loadingText) ?? "加载中";
     });
     const paginationConfig = vue.computed(() => props.pagination && typeof props.pagination === "object" ? props.pagination : {});
     const pageSize = vue.computed(() => {
       const value = paginationConfig.value.pageSize ?? paginationConfig.value.defaultPageSize ?? 10;
       return Number.isFinite(value) && value > 0 ? Math.max(1, Math.trunc(value)) : 1;
     });
-    const rawCurrentPage = vue.computed(() => paginationConfig.value.current ?? innerCurrent.value);
+    const rawCurrentPage = vue.computed(() => currentState.state.value ?? 1);
     const paginationTotal = vue.computed(() => paginationConfig.value.total ?? sortedData.value.length);
     const pageCount = vue.computed(() => Math.max(1, Math.ceil(Math.max(0, paginationTotal.value) / pageSize.value)));
     const currentPage = vue.computed(() => Math.min(Math.max(rawCurrentPage.value, 1), pageCount.value));
@@ -178,18 +200,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       return allRows.value.slice(start, start + pageSize.value);
     });
     vue.watch(
-      () => {
-        var _a2;
-        return (_a2 = props.rowSelection) == null ? void 0 : _a2.defaultSelectedRowKeys;
-      },
-      (keys) => {
-        var _a2;
-        if (!((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) && keys) {
-          innerSelectedRowKeys.value = keys;
-        }
-      }
-    );
-    vue.watch(
       normalizedColumns,
       (columns) => {
         if (!hasInitializedSort.value) {
@@ -205,13 +215,13 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         const nextFilters = { ...innerFilters.value };
         let shouldUpdateFilters = false;
         columns.forEach((column) => {
-          var _a2;
+          var _a;
           const key = getColumnKey(column);
           if (initializedFilterKeys.value.has(key)) {
             return;
           }
           initializedFilterKeys.value.add(key);
-          if (column.filteredValue === void 0 && ((_a2 = column.defaultFilteredValue) == null ? void 0 : _a2.length)) {
+          if (column.filteredValue === void 0 && ((_a = column.defaultFilteredValue) == null ? void 0 : _a.length)) {
             nextFilters[key] = [...column.defaultFilteredValue];
             shouldUpdateFilters = true;
           }
@@ -223,8 +233,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       { immediate: true }
     );
     vue.watch(pageCount, (count) => {
-      if (paginationConfig.value.current === void 0 && innerCurrent.value > count) {
-        innerCurrent.value = count;
+      if (!currentState.isControlled.value && (currentState.state.value ?? 1) > count) {
+        currentState.setState(count);
       }
     });
     function getColumnKey(column) {
@@ -300,20 +310,20 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       return text === void 0 || text === null ? "" : String(text);
     };
     const renderExpanded = (record, index2) => {
-      var _a2, _b2;
-      return ((_b2 = (_a2 = props.expandable) == null ? void 0 : _a2.expandedRowRender) == null ? void 0 : _b2.call(_a2, record, index2)) ?? "";
+      var _a, _b;
+      return ((_b = (_a = props.expandable) == null ? void 0 : _a.expandedRowRender) == null ? void 0 : _b.call(_a, record, index2)) ?? "";
     };
     const columnStyle = (column) => ({
       width: typeof column.width === "number" ? `${column.width}px` : column.width
     });
     const columnClass = (column) => {
-      var _a2;
+      var _a;
       return [
         column.className,
         column.align ? `aheart-table__cell--${column.align}` : void 0,
         {
           "is-sortable": Boolean(column.sorter),
-          "is-filtered": Boolean((_a2 = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a2.length),
+          "is-filtered": Boolean((_a = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a.length),
           "is-ellipsis": column.ellipsis
         }
       ];
@@ -357,8 +367,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       emitTableChange("sort", 1, pageSize.value, activeFilters.value, nextSort);
     };
     const isFilterActive = (column, value) => {
-      var _a2;
-      return Boolean((_a2 = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a2.includes(value));
+      var _a;
+      return Boolean((_a = activeFilters.value[getColumnKey(column)]) == null ? void 0 : _a.includes(value));
     };
     const toggleFilter = (column, value) => {
       if (isDisabled.value) {
@@ -379,45 +389,33 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       emitTableChange("filter", 1, pageSize.value, nextFilters, activeSort.value);
     };
     const resetInnerCurrent = () => {
-      if (paginationConfig.value.current === void 0) {
-        innerCurrent.value = 1;
-      }
+      currentState.setState(1);
     };
     const isSelected = (key) => selectedKeys.value.includes(key);
     const toggleSelection = (record, key, checked) => {
-      var _a2;
       if (isSelectionDisabled.value) {
         return;
       }
       const nextKeys = selectionType.value === "radio" ? checked ? [key] : [] : checked ? Array.from(/* @__PURE__ */ new Set([...selectedKeys.value, key])) : selectedKeys.value.filter((currentKey) => currentKey !== key);
-      if (((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) === void 0) {
-        innerSelectedRowKeys.value = nextKeys;
-      }
-      emit("update:selectedRowKeys", nextKeys);
+      selectedState.setState(nextKeys);
       emit("select", key, checked, record, nextKeys);
     };
     const isRowExpandable = (record) => {
-      var _a2, _b2;
-      return ((_b2 = (_a2 = props.expandable) == null ? void 0 : _a2.rowExpandable) == null ? void 0 : _b2.call(_a2, record)) ?? true;
+      var _a, _b;
+      return ((_b = (_a = props.expandable) == null ? void 0 : _a.rowExpandable) == null ? void 0 : _b.call(_a, record)) ?? true;
     };
     const isExpanded = (key) => expandedKeys.value.includes(key);
     const toggleExpand = (record, key) => {
-      var _a2;
       if (isDisabled.value) {
         return;
       }
       const nextExpanded = !isExpanded(key);
       const nextKeys = nextExpanded ? [...expandedKeys.value, key] : expandedKeys.value.filter((currentKey) => currentKey !== key);
-      if (((_a2 = props.expandable) == null ? void 0 : _a2.expandedRowKeys) === void 0) {
-        innerExpandedRowKeys.value = nextKeys;
-      }
-      emit("update:expandedRowKeys", nextKeys);
+      expandedState.setState(nextKeys);
       emit("expand", nextExpanded, record, key);
     };
     const handlePageChange = (current, nextPageSize) => {
-      if (paginationConfig.value.current === void 0) {
-        innerCurrent.value = current;
-      }
+      currentState.setState(current);
       emitTableChange("paginate", current, nextPageSize, activeFilters.value, activeSort.value);
     };
     const emitTableChange = (action, current, nextPageSize, filters, sortState) => {
@@ -441,14 +439,14 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       );
     };
     const getEventChecked = (event) => {
-      var _a2;
-      return Boolean((_a2 = event.target) == null ? void 0 : _a2.checked);
+      var _a;
+      return Boolean((_a = event.target) == null ? void 0 : _a.checked);
     };
     const handleSelectionChange = (event, record, key) => {
-      var _a2;
+      var _a;
       const input = event.target;
       toggleSelection(record, key, getEventChecked(event));
-      if (input && ((_a2 = props.rowSelection) == null ? void 0 : _a2.selectedRowKeys) !== void 0) {
+      if (input && ((_a = props.rowSelection) == null ? void 0 : _a.selectedRowKeys) !== void 0) {
         input.checked = isSelected(key);
       }
     };
@@ -474,7 +472,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                   }, null, -1)
                 ])])) : vue.createCommentVNode("", true),
                 (vue.openBlock(true), vue.createElementBlock(vue.Fragment, null, vue.renderList(normalizedColumns.value, (column) => {
-                  var _a2;
+                  var _a;
                   return vue.openBlock(), vue.createElementBlock("th", {
                     key: getColumnKey(column),
                     class: vue.normalizeClass(columnClass(column)),
@@ -506,7 +504,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                           node: column.title
                         }, null, 8, ["node"])
                       ])),
-                      ((_a2 = column.filters) == null ? void 0 : _a2.length) ? (vue.openBlock(), vue.createElementBlock("div", {
+                      ((_a = column.filters) == null ? void 0 : _a.length) ? (vue.openBlock(), vue.createElementBlock("div", {
                         key: 2,
                         class: "aheart-table__filters",
                         "aria-label": `${column.title} filters`
@@ -542,7 +540,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                     hasSelection.value ? (vue.openBlock(), vue.createElementBlock("td", _hoisted_13, [
                       vue.createElementVNode("input", {
                         type: selectionType.value,
-                        name: radioName,
+                        name: vue.unref(radioName),
                         checked: isSelected(row.key),
                         disabled: isSelectionDisabled.value,
                         "aria-label": `Select row ${row.key}`,

--- a/packages/components/lib/time-picker/time-picker.vue.js
+++ b/packages/components/lib/time-picker/time-picker.vue.js
@@ -6,7 +6,9 @@ const time = require("../picker-core/time.js");
 const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 const types = require("./types.js");
 require("./style.css.js");
@@ -57,13 +59,23 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const secondColumnRef = vue.ref(null);
     const periodColumnRef = vue.ref(null);
     const activeColumn = vue.ref("hour");
-    const internalValue = vue.ref(props.defaultValue);
-    const internalOpen = vue.ref(props.defaultOpen);
-    const instanceId = vue.useId().replace(/:/g, "");
-    const panelId = `aheart-time-${instanceId}-panel`;
+    const instanceId = useStableId.useStableId(void 0, "aheart-time").value;
+    const panelId = `${instanceId}-panel`;
     const isValueControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
     const isFormatProvided = usePropPresence.usePropPresence("format");
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = vue.defineComponent({
       name: "ATimePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -75,8 +87,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         };
       }
     });
-    const mergedValue = vue.computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = vue.computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
     const resolvedLocale = vue.computed(() => {
       var _a;
       return { ...context.zhCN.timePicker, ...(_a = config.value.locale) == null ? void 0 : _a.timePicker };
@@ -211,9 +223,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const requestOpen = (open) => {
       if (open && isInteractionDisabled.value)
         return;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (open) {
         syncDraft();
         activeColumn.value = "hour";
@@ -223,9 +233,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       if (isInteractionDisabled.value || isPartsDisabled(parts))
         return false;
       const value = formatTime(parts, props.valueFormat);
-      if (!isValueControlled.value)
-        internalValue.value = value;
-      emit("update:modelValue", value);
+      valueState.setState(value, { force: true });
       emit("change", value);
       if (isValueControlled.value && !props.needConfirm)
         syncDraft();
@@ -282,9 +290,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const clearValue = () => {
       if (isInteractionDisabled.value)
         return;
-      if (!isValueControlled.value)
-        internalValue.value = void 0;
-      emit("update:modelValue", void 0);
+      valueState.setState(void 0, { force: true });
       emit("change", void 0);
       emit("clear");
       requestOpen(false);
@@ -393,10 +399,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       if (open)
         void vue.nextTick(scrollSelectedOptionsIntoView);
     }, { immediate: true });
-    vue.watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-    });
     return (_ctx, _cache) => {
       return vue.openBlock(), vue.createElementBlock("span", {
         ref_key: "rootRef",

--- a/packages/components/lib/time-picker/time-range-picker.vue.js
+++ b/packages/components/lib/time-picker/time-range-picker.vue.js
@@ -6,7 +6,9 @@ const time = require("../picker-core/time.js");
 const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 const types = require("./types.js");
 require("./style.css.js");
@@ -72,14 +74,12 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const minuteColumnRef = vue.ref(null);
     const secondColumnRef = vue.ref(null);
     const periodColumnRef = vue.ref(null);
-    const internalValue = vue.ref(props.defaultValue ? [...props.defaultValue] : void 0);
-    const internalOpen = vue.ref(props.defaultOpen);
     const activePart = vue.ref("start");
     const activeColumn = vue.ref("hour");
     const draftValue = vue.ref();
     const draftParts = vue.ref([{ hour: 0, minute: 0, second: 0 }, { hour: 0, minute: 0, second: 0 }]);
     const liveMessage = vue.ref("");
-    const panelId = `aheart-time-range-${vue.useId().replace(/:/g, "")}-panel`;
+    const panelId = `${useStableId.useStableId(void 0, "aheart-time-range").value}-panel`;
     const instanceId = panelId.replace("-panel", "");
     const partPanelId = `${instanceId}-part-panel`;
     const startTabId = `${instanceId}-start-tab`;
@@ -87,6 +87,18 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const isValueControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
     const isFormatProvided = usePropPresence.usePropPresence("format");
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled: isValueControlled,
+      defaultValue: () => props.defaultValue ? [...props.defaultValue] : void 0,
+      onChange: (value) => emit("update:modelValue", value)
+    });
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => emit("openChange", Boolean(open))
+    });
     const ARenderNode = vue.defineComponent({
       name: "ATimeRangePickerRenderNode",
       props: { node: { type: null, default: void 0 } },
@@ -98,8 +110,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         };
       }
     });
-    const mergedValue = vue.computed(() => isValueControlled.value ? props.modelValue : internalValue.value);
-    const mergedOpen = vue.computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value));
+    const mergedValue = valueState.state;
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
     const resolvedLocale = vue.computed(() => {
       var _a;
       return { ...context.zhCN.timePicker, ...(_a = config.value.locale) == null ? void 0 : _a.timePicker };
@@ -270,9 +282,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       if (isInteractionDisabled.value)
         return false;
       if (!value) {
-        if (!isValueControlled.value)
-          internalValue.value = void 0;
-        emit("update:modelValue", void 0);
+        valueState.setState(void 0, { force: true });
         emit("change", void 0);
         if (close)
           requestOpen(false);
@@ -286,9 +296,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         if (parts && isPartsDisabled(parts, index === 0 ? "start" : "end"))
           return false;
       }
-      if (!isValueControlled.value)
-        internalValue.value = [...normalized];
-      emit("update:modelValue", normalized);
+      valueState.setState([...normalized], { force: true });
       emit("change", normalized);
       if (isValueControlled.value && !props.needConfirm)
         syncDraft();
@@ -407,9 +415,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       if (open && isInteractionDisabled.value)
         return;
       const wasOpen = mergedOpen.value;
-      if (!isOpenControlled.value)
-        internalOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
       if (open && !wasOpen)
         syncDraft();
     };

--- a/packages/components/lib/tree-select/tree-select.vue.js
+++ b/packages/components/lib/tree-select/tree-select.vue.js
@@ -7,6 +7,7 @@ const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
+const useControllableState = require("../utils/use-controllable-state.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 require("./style.css.js");
 const _hoisted_1 = ["id", "tabindex", "aria-expanded", "aria-disabled", "aria-labelledby"];
@@ -55,14 +56,30 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const rootRef = vue.ref(null);
     const triggerRef = vue.ref(null);
     const panelRef = vue.ref(null);
-    const innerOpen = vue.ref(props.defaultOpen);
     const searchText = vue.ref("");
-    const innerValue = vue.ref(props.defaultValue);
     const isControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
-    const mergedOpen = vue.computed(() => isOpenControlled.value ? props.open : innerOpen.value);
     const resolvedAriaLabelledby = vue.computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs["aria-labelledby"]);
-    const mergedValue = vue.computed(() => isControlled.value ? props.modelValue : innerValue.value);
+    const openState = useControllableState.useControllableState({
+      controlled: () => props.open,
+      isControlled: isOpenControlled,
+      defaultValue: () => props.defaultOpen,
+      onChange: (open) => {
+        const nextOpen = Boolean(open);
+        emit("openChange", nextOpen);
+      }
+    });
+    const valueState = useControllableState.useControllableState({
+      controlled: () => props.modelValue,
+      isControlled,
+      defaultValue: () => props.defaultValue,
+      onChange: (value) => {
+        emit("update:modelValue", value);
+        emit("change", value);
+      }
+    });
+    const mergedOpen = vue.computed(() => Boolean(openState.state.value));
+    const mergedValue = valueState.state;
     const selectedKeys = vue.computed(() => Array.isArray(mergedValue.value) ? mergedValue.value : mergedValue.value === void 0 ? [] : [mergedValue.value]);
     const flattenNodes = (nodes) => nodes.flatMap((node) => [node, ...flattenNodes(node.children ?? [])]);
     const displayLabel = vue.computed(() => selectedKeys.value.map((key) => {
@@ -98,15 +115,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const requestOpen = (open) => {
       if (props.disabled)
         return;
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
-      emit("openChange", open);
+      openState.setState(open, { force: true });
     };
     const emitValue = (value) => {
-      if (!isControlled.value)
-        innerValue.value = value;
-      emit("update:modelValue", value);
-      emit("change", value);
+      valueState.setState(value, { force: true });
     };
     const handleSelect = (keys) => {
       const value = props.multiple ? keys : keys[0];
@@ -175,10 +187,6 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       trigger: triggerRef,
       floating: panelRef,
       onDismiss: () => requestOpen(false)
-    });
-    vue.watch(() => props.defaultOpen, (open) => {
-      if (!isOpenControlled.value)
-        innerOpen.value = open;
     });
     return (_ctx, _cache) => {
       return vue.openBlock(), vue.createElementBlock("div", {

--- a/packages/components/lib/upload/upload.vue.js
+++ b/packages/components/lib/upload/upload.vue.js
@@ -1,6 +1,8 @@
 "use strict";
 Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: "Module" } });
 const vue = require("vue");
+const useControllableState = require("../utils/use-controllable-state.js");
+const usePropPresence = require("../utils/use-prop-presence.js");
 require("./style.css.js");
 const context = require("../config/context.js");
 const _hoisted_1 = { class: "aheart-upload__trigger" };
@@ -35,21 +37,25 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       var _a, _b;
       return ((_b = (_a = config.value.locale) == null ? void 0 : _a.datePicker) == null ? void 0 : _b.locale) === "en-US" ? { selectFile: "Select file", upload: "Upload", done: "Done", failed: "Failed", removeAction: "Remove", remove: (name) => `Remove ${name}` } : { selectFile: "选择文件", upload: "上传", done: "已完成", failed: "上传失败", removeAction: "移除", remove: (name) => `移除 ${name}` };
     });
-    const internalFileList = vue.ref([...props.defaultFileList]);
-    const mergedFileList = vue.computed(() => props.fileList ?? internalFileList.value);
+    const isFileListControlled = usePropPresence.usePropPresence("fileList", "file-list");
+    const fileListState = useControllableState.useControllableState({
+      controlled: () => props.fileList,
+      isControlled: isFileListControlled,
+      defaultValue: () => [...props.defaultFileList],
+      onChange: (files) => emit("update:fileList", files ?? [])
+    });
+    const mergedFileList = vue.computed(() => fileListState.state.value ?? []);
     const readyFiles = vue.computed(() => mergedFileList.value.filter((file) => file.status === "ready"));
     const latestFileList = vue.ref([...props.fileList ?? props.defaultFileList]);
     let uid = 0;
     const activeUploadUids = /* @__PURE__ */ new Set();
     vue.watch(() => props.fileList, (fileList) => {
-      if (fileList !== void 0)
-        latestFileList.value = [...fileList];
+      if (isFileListControlled.value)
+        latestFileList.value = [...fileList ?? []];
     }, { deep: true });
     const updateFileList = (files) => {
       latestFileList.value = files;
-      if (props.fileList === void 0)
-        internalFileList.value = files;
-      emit("update:fileList", files);
+      fileListState.setState(files);
       emit("change", files);
     };
     const replaceFile = (file) => {
@@ -108,13 +114,17 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         return;
       const files = Array.from(event.target.files ?? []);
       event.target.value = "";
-      let nextFiles = props.fileList === void 0 ? latestFileList.value : [...props.fileList];
+      let nextFiles = isFileListControlled.value ? [...props.fileList ?? []] : latestFileList.value;
       latestFileList.value = nextFiles;
-      const remaining = Math.max(0, props.maxCount - nextFiles.length);
-      for (const rawFile of files.slice(0, remaining)) {
+      for (const rawFile of files) {
+        if (nextFiles.length >= props.maxCount)
+          break;
         const uploadFile = toUploadFile(rawFile);
         const shouldUpload = await ((_a = props.beforeUpload) == null ? void 0 : _a.call(props, rawFile, [...nextFiles, uploadFile]));
-        nextFiles = [...nextFiles, uploadFile];
+        const currentFiles = isFileListControlled.value ? [...props.fileList ?? []] : latestFileList.value;
+        if (currentFiles.length >= props.maxCount)
+          continue;
+        nextFiles = [...currentFiles, uploadFile];
         updateFileList(nextFiles);
         if (shouldUpload !== false)
           nextFiles = await upload(uploadFile, nextFiles);

--- a/packages/components/lib/utils/use-async-task.d.ts
+++ b/packages/components/lib/utils/use-async-task.d.ts
@@ -1,0 +1,18 @@
+export type AsyncTaskStatus = 'idle' | 'pending' | 'success' | 'error';
+export interface AsyncTaskContext {
+    signal: AbortSignal;
+    requestId: number;
+}
+export interface AsyncTaskOptions<TResult> {
+    onSuccess?: (result: TResult) => void;
+    onError?: (error: unknown) => void;
+}
+export declare const useAsyncTask: <TArgs extends unknown[], TResult>(task: (context: AsyncTaskContext, ...args: TArgs) => Promise<TResult>, options?: AsyncTaskOptions<TResult>) => {
+    status: Readonly<import("vue").Ref<AsyncTaskStatus, AsyncTaskStatus>>;
+    data: Readonly<import("vue").Ref<import("vue").DeepReadonly<TResult> | undefined, import("vue").DeepReadonly<TResult> | undefined>>;
+    error: Readonly<import("vue").Ref<Readonly<unknown>, Readonly<unknown>>>;
+    isPending: import("vue").ComputedRef<boolean>;
+    run: (...args: TArgs) => Promise<TResult | undefined>;
+    abort: () => void;
+    reset: () => void;
+};

--- a/packages/components/lib/utils/use-async-task.js
+++ b/packages/components/lib/utils/use-async-task.js
@@ -1,0 +1,61 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const vue = require("vue");
+const useAsyncTask = (task, options = {}) => {
+  const status = vue.shallowRef("idle");
+  const data = vue.shallowRef();
+  const error = vue.shallowRef();
+  let requestId = 0;
+  let controller;
+  const abort = () => {
+    requestId += 1;
+    controller == null ? void 0 : controller.abort();
+    controller = void 0;
+    if (status.value === "pending")
+      status.value = "idle";
+  };
+  const reset = () => {
+    abort();
+    status.value = "idle";
+    data.value = void 0;
+    error.value = void 0;
+  };
+  const run = async (...args) => {
+    var _a, _b;
+    controller == null ? void 0 : controller.abort();
+    const currentController = new AbortController();
+    const currentRequestId = ++requestId;
+    controller = currentController;
+    status.value = "pending";
+    error.value = void 0;
+    try {
+      const result = await task({ signal: currentController.signal, requestId: currentRequestId }, ...args);
+      if (currentController.signal.aborted || currentRequestId !== requestId)
+        return void 0;
+      controller = void 0;
+      data.value = result;
+      status.value = "success";
+      (_a = options.onSuccess) == null ? void 0 : _a.call(options, result);
+      return result;
+    } catch (reason) {
+      if (currentController.signal.aborted || currentRequestId !== requestId)
+        return void 0;
+      controller = void 0;
+      error.value = reason;
+      status.value = "error";
+      (_b = options.onError) == null ? void 0 : _b.call(options, reason);
+      return void 0;
+    }
+  };
+  vue.onBeforeUnmount(abort);
+  return {
+    status: vue.readonly(status),
+    data: vue.readonly(data),
+    error: vue.readonly(error),
+    isPending: vue.computed(() => status.value === "pending"),
+    run,
+    abort,
+    reset
+  };
+};
+exports.useAsyncTask = useAsyncTask;

--- a/packages/components/lib/utils/use-collection.d.ts
+++ b/packages/components/lib/utils/use-collection.d.ts
@@ -1,0 +1,30 @@
+import { type Ref } from 'vue';
+export interface CollectionItem<T extends HTMLElement = HTMLElement> {
+    key: string;
+    element: T;
+    disabled: boolean;
+    visible: boolean;
+}
+export interface CollectionRegistration<T extends HTMLElement = HTMLElement> {
+    key?: string;
+    element: T;
+    disabled?: boolean;
+    visible?: boolean;
+}
+export interface UseCollectionReturn<T extends HTMLElement = HTMLElement> {
+    items: Ref<CollectionItem<T>[]>;
+    register: (item: CollectionRegistration<T>) => {
+        key: string;
+        unregister: () => void;
+    };
+    unregister: (key: string) => void;
+    update: (key: string, patch: Partial<Pick<CollectionItem<T>, 'element' | 'disabled' | 'visible'>>) => void;
+    getItem: (key: string) => CollectionItem<T> | undefined;
+    getItems: () => CollectionItem<T>[];
+    getVisibleItems: () => CollectionItem<T>[];
+    getEnabledItems: () => CollectionItem<T>[];
+    isVisible: (key: string) => boolean;
+    isDisabled: (key: string) => boolean;
+}
+/** Internal ordered registry shared by composite components. */
+export declare function useCollection<T extends HTMLElement = HTMLElement>(): UseCollectionReturn<T>;

--- a/packages/components/lib/utils/use-collection.js
+++ b/packages/components/lib/utils/use-collection.js
@@ -1,0 +1,51 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const vue = require("vue");
+function useCollection() {
+  const items = vue.shallowRef([]);
+  let nextKey = 0;
+  const makeKey = () => `collection-item-${++nextKey}`;
+  const getItem = (key) => items.value.find((item) => item.key === key);
+  const getItems = () => items.value.slice();
+  const getVisibleItems = () => items.value.filter((item) => item.visible);
+  const getEnabledItems = () => items.value.filter((item) => item.visible && !item.disabled);
+  const unregister = (key) => {
+    const index = items.value.findIndex((item) => item.key === key);
+    if (index >= 0)
+      items.value = items.value.filter((item) => item.key !== key);
+  };
+  const register = (input) => {
+    const key = input.key || makeKey();
+    const existing = getItem(key);
+    if (existing) {
+      items.value = items.value.map((item) => item.key === key ? { ...item, element: input.element, disabled: !!input.disabled, visible: input.visible !== false } : item);
+    } else {
+      items.value = [...items.value, { key, element: input.element, disabled: !!input.disabled, visible: input.visible !== false }];
+    }
+    return { key, unregister: () => unregister(key) };
+  };
+  const update = (key, patch) => {
+    const item = getItem(key);
+    if (item)
+      items.value = items.value.map((entry) => entry.key === key ? { ...entry, ...patch } : entry);
+  };
+  return {
+    items,
+    register,
+    unregister,
+    update,
+    getItem,
+    getItems,
+    getVisibleItems,
+    getEnabledItems,
+    isVisible: (key) => {
+      var _a;
+      return ((_a = getItem(key)) == null ? void 0 : _a.visible) === true;
+    },
+    isDisabled: (key) => {
+      var _a;
+      return ((_a = getItem(key)) == null ? void 0 : _a.disabled) === true;
+    }
+  };
+}
+exports.useCollection = useCollection;

--- a/packages/components/lib/utils/use-controllable-state.d.ts
+++ b/packages/components/lib/utils/use-controllable-state.d.ts
@@ -1,0 +1,22 @@
+import { type MaybeRefOrGetter, type Ref } from 'vue';
+export interface UseControllableStateOptions<T> {
+    /** Presence of this property opts into controlled mode, including an undefined value. */
+    controlled?: MaybeRefOrGetter<T | undefined>;
+    /** Overrides property-presence detection when controlledness changes at runtime. */
+    isControlled?: MaybeRefOrGetter<boolean>;
+    defaultValue?: MaybeRefOrGetter<T | undefined>;
+    onChange?: (value: T | undefined) => void;
+}
+export interface UseControllableStateReturn<T> {
+    state: Readonly<Ref<T | undefined>>;
+    isControlled: Readonly<Ref<boolean>>;
+    setState: (next: T | undefined | ((current: T | undefined) => T | undefined), options?: {
+        force?: boolean;
+    }) => boolean;
+}
+/**
+ * Small internal state bridge for controls that support both v-model and defaults.
+ * Controlled state is always read from its owner, so rejected update events cannot
+ * leave an optimistic value behind.
+ */
+export declare const useControllableState: <T>(options: UseControllableStateOptions<T>) => UseControllableStateReturn<T>;

--- a/packages/components/lib/utils/use-controllable-state.js
+++ b/packages/components/lib/utils/use-controllable-state.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const vue = require("vue");
+const useControllableState = (options) => {
+  const controlledByPresence = Object.prototype.hasOwnProperty.call(options, "controlled");
+  const isControlled = vue.computed(() => options.isControlled === void 0 ? controlledByPresence : vue.toValue(options.isControlled));
+  const uncontrolled = vue.ref(vue.toValue(options.defaultValue));
+  const state = vue.computed(() => isControlled.value ? vue.toValue(options.controlled) : uncontrolled.value);
+  vue.watch(
+    [isControlled, () => vue.toValue(options.controlled)],
+    ([controlled, value]) => {
+      if (controlled)
+        uncontrolled.value = value;
+    },
+    { flush: "sync", immediate: true }
+  );
+  const setState = (next, setOptions = {}) => {
+    var _a;
+    const value = typeof next === "function" ? next(state.value) : next;
+    if (!setOptions.force && Object.is(value, state.value)) {
+      return false;
+    }
+    if (!isControlled.value) {
+      uncontrolled.value = value;
+    }
+    (_a = options.onChange) == null ? void 0 : _a.call(options, value);
+    return true;
+  };
+  return { state, isControlled, setState };
+};
+exports.useControllableState = useControllableState;

--- a/packages/components/lib/utils/use-roving-focus.d.ts
+++ b/packages/components/lib/utils/use-roving-focus.d.ts
@@ -1,0 +1,14 @@
+import { type MaybeRefOrGetter } from 'vue';
+import type { UseCollectionReturn } from './use-collection';
+export type RovingOrientation = 'horizontal' | 'vertical' | 'both';
+export interface UseRovingFocusOptions<T extends HTMLElement = HTMLElement> {
+    collection: UseCollectionReturn<T> | MaybeRefOrGetter<UseCollectionReturn<T>>;
+    orientation?: RovingOrientation | MaybeRefOrGetter<RovingOrientation>;
+    loop?: boolean | MaybeRefOrGetter<boolean>;
+    preventDefault?: boolean | MaybeRefOrGetter<boolean>;
+}
+export declare function useRovingFocus<T extends HTMLElement = HTMLElement>(options: UseRovingFocusOptions<T>): {
+    getNextKey: (currentKey: string | undefined, key: string) => string | undefined;
+    focus: (key: string, preventScroll?: boolean) => boolean;
+    onKeydown: (event: KeyboardEvent, currentKey?: string) => boolean;
+};

--- a/packages/components/lib/utils/use-roving-focus.js
+++ b/packages/components/lib/utils/use-roving-focus.js
@@ -1,0 +1,50 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const vue = require("vue");
+function useRovingFocus(options) {
+  const collection = () => vue.toValue(options.collection);
+  const orientation = () => vue.toValue(options.orientation) ?? "both";
+  const loops = () => vue.toValue(options.loop) !== false;
+  const shouldPrevent = () => vue.toValue(options.preventDefault) !== false;
+  const isDirection = (key) => {
+    if (orientation() === "horizontal")
+      return key === "ArrowLeft" || key === "ArrowRight";
+    if (orientation() === "vertical")
+      return key === "ArrowUp" || key === "ArrowDown";
+    return key.startsWith("Arrow");
+  };
+  const getNextKey = (currentKey, key) => {
+    const entries = collection().getEnabledItems();
+    if (!entries.length || key !== "Home" && key !== "End" && !isDirection(key))
+      return void 0;
+    if (key === "Home")
+      return entries[0].key;
+    if (key === "End")
+      return entries[entries.length - 1].key;
+    const forward = key === "ArrowRight" || key === "ArrowDown";
+    const index = entries.findIndex((item) => item.key === currentKey);
+    if (index < 0)
+      return forward ? entries[0].key : entries[entries.length - 1].key;
+    const next = index + (forward ? 1 : -1);
+    if (next >= 0 && next < entries.length)
+      return entries[next].key;
+    return loops() ? entries[(next + entries.length) % entries.length].key : void 0;
+  };
+  const focus = (key, preventScroll = true) => {
+    const item = collection().getItem(key);
+    if (!item || !item.visible || item.disabled)
+      return false;
+    item.element.focus({ preventScroll });
+    return true;
+  };
+  const onKeydown = (event, currentKey) => {
+    const nextKey = getNextKey(currentKey, event.key);
+    if (!nextKey)
+      return false;
+    if (shouldPrevent())
+      event.preventDefault();
+    return focus(nextKey);
+  };
+  return { getNextKey, focus, onKeydown };
+}
+exports.useRovingFocus = useRovingFocus;

--- a/packages/components/lib/utils/use-stable-id.d.ts
+++ b/packages/components/lib/utils/use-stable-id.d.ts
@@ -1,0 +1,3 @@
+import { type MaybeRefOrGetter, type ComputedRef } from 'vue';
+/** Returns an explicit id when supplied, otherwise a Vue SSR-safe generated id. */
+export declare const useStableId: (explicitId?: MaybeRefOrGetter<string | undefined>, prefix?: string) => ComputedRef<string>;

--- a/packages/components/lib/utils/use-stable-id.js
+++ b/packages/components/lib/utils/use-stable-id.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const vue = require("vue");
+const useStableId = (explicitId, prefix = "aheart") => {
+  const generatedId = `${prefix}-${vue.useId().replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+  return vue.computed(() => vue.toValue(explicitId) ?? generatedId);
+};
+exports.useStableId = useStableId;

--- a/packages/components/src/cascader/cascader.vue
+++ b/packages/components/src/cascader/cascader.vue
@@ -94,6 +94,7 @@ import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import type { CascaderKey, CascaderOption, CascaderPath, CascaderValue } from './types'
 import './style.css'
@@ -137,16 +138,32 @@ const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
 const columnsRef = ref<HTMLElement | null>(null)
-const innerOpen = ref(props.defaultOpen)
 const searchText = ref('')
 const activePath = ref<CascaderPath>([])
 const loadingPaths = ref<CascaderPath[]>([])
 const innerOptions = ref<CascaderOption[]>(cloneOptions(props.options))
-const innerValue = ref<CascaderValue>(props.defaultValue)
 const isControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
-const mergedOpen = computed(() => isOpenControlled.value ? props.open : innerOpen.value)
-const mergedValue = computed(() => isControlled.value ? props.modelValue : innerValue.value)
+const openState = useControllableState({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => {
+    const nextOpen = Boolean(open)
+    emit('openChange', nextOpen)
+  }
+})
+const valueState = useControllableState<CascaderValue>({
+  controlled: () => props.modelValue,
+  isControlled,
+  defaultValue: () => props.defaultValue,
+  onChange: (value) => {
+    emit('update:modelValue', value)
+    emit('change', value)
+  }
+})
+const mergedOpen = computed(() => Boolean(openState.state.value))
+const mergedValue = valueState.state
 const selectedPaths = computed<CascaderPath[]>(() => {
   if (props.multiple) {
     return Array.isArray(mergedValue.value) && mergedValue.value.every(Array.isArray)
@@ -226,14 +243,11 @@ const isSelected = (columnIndex: number, option: CascaderOption) => selectedPath
 const isLoading = (columnIndex: number, option: CascaderOption) => loadingPaths.value.some((path) => samePath(path, [...activePath.value.slice(0, columnIndex), option.value]))
 const requestOpen = (open: boolean) => {
   if (props.disabled) return
-  if (!isOpenControlled.value) innerOpen.value = open
-  emit('openChange', open)
+  openState.setState(open, { force: true })
 }
 const toggleOpen = () => requestOpen(!mergedOpen.value)
 const emitValue = (value: CascaderValue) => {
-  if (!isControlled.value) innerValue.value = value
-  emit('update:modelValue', value)
-  emit('change', value)
+  valueState.setState(value, { force: true })
 }
 const clearValue = () => {
   emitValue(props.multiple ? [] : undefined)
@@ -346,7 +360,4 @@ useFloatingDismiss({
   onDismiss: () => requestOpen(false)
 })
 
-watch(() => props.defaultOpen, (open) => {
-  if (!isOpenControlled.value) innerOpen.value = open
-})
 </script>

--- a/packages/components/src/date-picker/date-picker.vue
+++ b/packages/components/src/date-picker/date-picker.vue
@@ -185,7 +185,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, isVNode, nextTick, onMounted, ref, toRaw, useId, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
+import { computed, defineComponent, h, isVNode, nextTick, onMounted, ref, toRaw, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
 import { resolveConfigValue, useAheartConfig, zhCN } from '../config'
 import AIcon from '../icon/icon.vue'
 import { createDateMatrix, isPickerDateDisabled } from '../picker-core/calendar'
@@ -196,7 +196,9 @@ import type { DatePickerValue, DatePickerCellRenderInfo } from './types'
 import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import { datePickerEmits, datePickerProps } from './types'
 import './style.css'
@@ -211,17 +213,26 @@ const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const inputRef = ref<HTMLInputElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
-const internalValue = ref<DatePickerValue>(props.defaultValue)
-const internalOpen = ref(props.defaultOpen)
 const draftValue = ref<DatePickerValue>()
 const inputText = ref('')
 const activeCellKey = ref('')
 const liveMessage = ref('')
-const instanceId = useId().replace(/:/g, '')
-const panelId = `aheart-date-picker-${instanceId}-panel`
+const panelId = `${useStableId(undefined, 'aheart-date-picker').value}-panel`
 const isValueControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
 const isPanelControlled = usePropPresence('pickerValue', 'picker-value')
+const valueState = useControllableState<DatePickerValue>({
+  controlled: () => props.modelValue,
+  isControlled: isValueControlled,
+  defaultValue: () => props.defaultValue,
+  onChange: (value) => emit('update:modelValue', value)
+})
+const openState = useControllableState<boolean>({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => emit('openChange', Boolean(open))
+})
 
 const ARenderNode = defineComponent({
   name: 'ADatePickerRenderNode',
@@ -235,8 +246,8 @@ const ARenderNode = defineComponent({
   }
 })
 
-const mergedValue = computed<DatePickerValue>(() => isValueControlled.value ? props.modelValue : internalValue.value)
-const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value))
+const mergedValue = valueState.state
+const mergedOpen = computed(() => Boolean(openState.state.value))
 const selectedValues = computed(() => Array.isArray(mergedValue.value)
   ? mergedValue.value
   : mergedValue.value ? [mergedValue.value] : [])
@@ -446,8 +457,7 @@ let restoreFocusOnClose = false
 const requestOpen = (nextOpen: boolean, restoreFocus = false) => {
   if (nextOpen && (isDisabled.value || props.readOnly)) return
   if (!nextOpen) restoreFocusOnClose = restoreFocus
-  if (!isOpenControlled.value) internalOpen.value = nextOpen
-  emit('openChange', nextOpen)
+  openState.setState(nextOpen, { force: true })
 }
 let restoringFocus = false
 const handleFocus = () => {
@@ -482,8 +492,7 @@ useFloatingDismiss({
 
 const commitValue = (value: DatePickerValue, close = true) => {
   const normalized = Array.isArray(value) ? normalizeMultipleValues(value) : value
-  if (!isValueControlled.value) internalValue.value = normalized
-  emit('update:modelValue', normalized)
+  valueState.setState(normalized, { force: true })
   emit('change', normalized)
   if (isValueControlled.value) {
     void nextTick(() => { inputText.value = committedInputText.value })

--- a/packages/components/src/date-picker/date-range-picker.vue
+++ b/packages/components/src/date-picker/date-range-picker.vue
@@ -157,7 +157,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, isVNode, nextTick, onMounted, ref, toRaw, useId, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
+import { computed, defineComponent, h, isVNode, nextTick, onMounted, ref, toRaw, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
 import { resolveConfigValue, useAheartConfig, zhCN } from '../config'
 import AIcon from '../icon/icon.vue'
 import { createDateMatrix, isPickerDateDisabled } from '../picker-core/calendar'
@@ -168,7 +168,9 @@ import type { RangePickerPart, RangePickerValue } from '../picker-core/types'
 import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import { dateRangePickerEmits, dateRangePickerProps, type DatePickerCellRenderInfo } from './types'
 import './style.css'
@@ -184,8 +186,6 @@ const triggerRef = ref<HTMLElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
 const startInputRef = ref<HTMLInputElement | null>(null)
 const endInputRef = ref<HTMLInputElement | null>(null)
-const internalValue = ref<RangePickerValue>(props.defaultValue ? [...props.defaultValue] as RangePickerValue : undefined)
-const internalOpen = ref(props.defaultOpen)
 const draftValue = ref<RangePickerValue>()
 const activePart = ref<RangePickerPart>('start')
 const activeKeyboardDate = ref<PickerDate>()
@@ -195,10 +195,22 @@ const liveMessage = ref('')
 const inputTexts = ref<[string, string]>(['', ''])
 const nowDate = ref<PickerDate>()
 const rangeParts: RangePickerPart[] = ['start', 'end']
-const panelId = `aheart-date-range-picker-${useId().replace(/:/g, '')}-panel`
+const panelId = `${useStableId(undefined, 'aheart-date-range-picker').value}-panel`
 const isValueControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
 const isPanelControlled = usePropPresence('pickerValue', 'picker-value')
+const valueState = useControllableState<RangePickerValue>({
+  controlled: () => props.modelValue,
+  isControlled: isValueControlled,
+  defaultValue: () => props.defaultValue ? [...props.defaultValue] as RangePickerValue : undefined,
+  onChange: (value) => emit('update:modelValue', value)
+})
+const openState = useControllableState<boolean>({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => emit('openChange', Boolean(open))
+})
 
 const ARenderNode = defineComponent({
   name: 'ADateRangePickerRenderNode',
@@ -212,8 +224,8 @@ const ARenderNode = defineComponent({
   }
 })
 
-const mergedValue = computed<RangePickerValue>(() => isValueControlled.value ? props.modelValue : internalValue.value)
-const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value))
+const mergedValue = valueState.state
+const mergedOpen = computed(() => Boolean(openState.state.value))
 const effectiveShowTime = computed(() => Boolean(props.showTime) && props.picker === 'date')
 const showTimeOptions = computed(() => typeof props.showTime === 'object' ? props.showTime : {})
 const effectiveNeedConfirm = computed(() => props.needConfirm ?? effectiveShowTime.value)
@@ -412,8 +424,7 @@ watch(() => motion.phase.value, (phase) => { if (phase === 'entered') void nextT
 let restoringFocus = false
 const requestOpen = (open: boolean, restoreFocus = false) => {
   if (open && (isDisabled.value || props.readOnly)) return
-  if (!isOpenControlled.value) internalOpen.value = open
-  emit('openChange', open)
+  openState.setState(open, { force: true })
   if (!open && restoreFocus) void nextTick(() => {
     restoringFocus = true
     ;(activePart.value === 'start' ? startInputRef.value : endInputRef.value)?.focus()
@@ -527,8 +538,7 @@ const commitInput = (part: RangePickerPart) => {
 
 const commitValue = (value: RangePickerValue, close = true) => {
   const normalized = normalizeRangeValue(value, resolvedValueFormat.value, props.order, props.allowEmpty) ?? value
-  if (!isValueControlled.value) internalValue.value = normalized ? [...normalized] as RangePickerValue : undefined
-  emit('update:modelValue', normalized)
+  valueState.setState(normalized ? [...normalized] as RangePickerValue : undefined, { force: true })
   emit('change', normalized)
   if (isValueControlled.value) void nextTick(syncInputs)
   if (close) requestOpen(false, true)

--- a/packages/components/src/select/__tests__/select.test.ts
+++ b/packages/components/src/select/__tests__/select.test.ts
@@ -172,6 +172,18 @@ describe('Select', () => {
     expect(wrapper.get('.aheart-select__value').text()).toBe('Apple')
   })
 
+  it('uses default props only for initialization', async () => {
+    const wrapper = mountSelect({ props: { options, defaultValue: 'banana', defaultOpen: true } })
+    await wrapper.findAll('[role="option"]')[0].trigger('click')
+    expect(wrapper.get('.aheart-select__value').text()).toBe('Apple')
+    expect(wrapper.get('[role="combobox"]').attributes('aria-expanded')).toBe('false')
+
+    await wrapper.setProps({ defaultValue: 'banana', defaultOpen: false })
+    await wrapper.setProps({ defaultOpen: true })
+    expect(wrapper.get('.aheart-select__value').text()).toBe('Apple')
+    expect(wrapper.get('[role="combobox"]').attributes('aria-expanded')).toBe('false')
+  })
+
   it('emits focus and blur and exposes imperative focus methods', async () => {
     const host = document.createElement('div')
     document.body.appendChild(host)

--- a/packages/components/src/select/select.vue
+++ b/packages/components/src/select/select.vue
@@ -170,13 +170,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, nextTick, ref, useAttrs, useId, useSlots, watch, type PropType, type VNodeChild } from 'vue'
+import { computed, defineComponent, nextTick, ref, useAttrs, useSlots, watch, type PropType, type VNodeChild } from 'vue'
 import { resolveConfigValue, useAheartConfig } from '../config'
 import AIcon from '../icon/icon.vue'
 import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import {
   selectEmits,
@@ -201,12 +203,9 @@ const selectorRef = ref<HTMLElement | null>(null)
 const searchRef = ref<HTMLInputElement | null>(null)
 const popupRef = ref<HTMLElement | null>(null)
 const internalSearchValue = ref('')
-const internalValue = ref<SelectValue | undefined>(props.defaultValue)
-const internalOpen = ref(props.defaultOpen)
 const activeIndex = ref(-1)
 const focused = ref(false)
-const instanceId = useId().replace(/:/g, '')
-const listboxId = `aheart-select-${instanceId}-listbox`
+const listboxId = `${useStableId(undefined, 'aheart-select').value}-listbox`
 
 const ARenderNode = defineComponent({
   name: 'ASelectRenderNode',
@@ -235,10 +234,26 @@ const normalizedOptions = computed(() => rawOptions.value.map(normalizeOption))
 const isMultiple = computed(() => props.mode === 'multiple' || props.mode === 'tags')
 const isSearchable = computed(() => props.showSearch || props.mode === 'tags')
 const isControlled = usePropPresence('modelValue', 'model-value')
-const mergedValue = computed(() => (isControlled.value ? props.modelValue : internalValue.value))
 const isOpenControlled = usePropPresence('open')
 const isSearchControlled = usePropPresence('searchValue', 'search-value')
-const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value))
+const valueState = useControllableState<SelectValue>({
+  controlled: () => props.modelValue,
+  isControlled,
+  defaultValue: () => props.defaultValue,
+  onChange: (value) => {
+    if (value === undefined) return
+    emit('update:modelValue', value)
+    emit('change', value)
+  }
+})
+const openState = useControllableState<boolean>({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => emit('openChange', Boolean(open))
+})
+const mergedValue = valueState.state
+const mergedOpen = computed(() => Boolean(openState.state.value))
 const currentSearchValue = computed(() => isSearchControlled.value ? props.searchValue ?? '' : internalSearchValue.value)
 const resolvedAriaLabelledby = computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs['aria-labelledby'] as string | undefined)
 const resolvedSize = computed(() => resolveConfigValue(props.size, config.value.size, 'middle'))
@@ -360,8 +375,7 @@ const setInitialActive = () => {
 }
 const requestOpen = (open: boolean) => {
   if (isDisabled.value) return
-  if (!isOpenControlled.value) internalOpen.value = open
-  emit('openChange', open)
+  openState.setState(open, { force: true })
   if (open) setInitialActive()
 }
 const openPopup = () => {
@@ -375,9 +389,7 @@ const handleSelectorClick = () => {
 }
 
 const emitValue = (value: SelectValue) => {
-  if (!isControlled.value) internalValue.value = value
-  emit('update:modelValue', value)
-  emit('change', value)
+  valueState.setState(value, { force: true })
 }
 const clearSearch = () => {
   if (!isSearchControlled.value) internalSearchValue.value = ''
@@ -492,10 +504,6 @@ useFloatingDismiss({
 watch(filteredOptions, () => {
   if (mergedOpen.value) setInitialActive()
 })
-watch(() => props.defaultOpen, (open) => {
-  if (!isOpenControlled.value) internalOpen.value = open
-})
-
 const focus = () => (isSearchable.value ? searchRef.value : selectorRef.value)?.focus()
 const blur = () => {
   searchRef.value?.blur()

--- a/packages/components/src/table/__tests__/table.test.ts
+++ b/packages/components/src/table/__tests__/table.test.ts
@@ -294,6 +294,46 @@ describe('Table', () => {
     expect(wrapper.emitted('select')?.[0]?.[0]).toBe('grace')
   })
 
+  it('does not let changed default selection overwrite runtime state', async () => {
+    const wrapper = mount(Table, {
+      props: {
+        columns,
+        dataSource,
+        rowSelection: { defaultSelectedRowKeys: ['ada'] }
+      }
+    })
+    await wrapper.findAll('tbody input[type="checkbox"]')[1].setValue(true)
+    expect(wrapper.emitted('update:selectedRowKeys')?.at(-1)).toEqual([['ada', 'grace']])
+
+    await wrapper.setProps({ rowSelection: { defaultSelectedRowKeys: ['linus'] } })
+    const checked = wrapper.findAll('tbody input[type="checkbox"]')
+      .map((input) => (input.element as HTMLInputElement).checked)
+    expect(checked).toEqual([true, true, false])
+  })
+
+  it('supports runtime controlled handoff and explicit undefined selection', async () => {
+    const wrapper = mount(Table, {
+      props: {
+        columns,
+        dataSource,
+        rowSelection: { defaultSelectedRowKeys: ['ada'] }
+      }
+    })
+    await wrapper.findAll('tbody input[type="checkbox"]')[1].setValue(true)
+
+    await wrapper.setProps({ rowSelection: { selectedRowKeys: ['linus'] } })
+    let checked = wrapper.findAll('tbody input[type="checkbox"]')
+      .map((input) => (input.element as HTMLInputElement).checked)
+    expect(checked).toEqual([false, false, true])
+    await wrapper.findAll('tbody input[type="checkbox"]')[0].setValue(true)
+    expect(wrapper.emitted('update:selectedRowKeys')?.at(-1)).toEqual([['linus', 'ada']])
+
+    await wrapper.setProps({ rowSelection: { selectedRowKeys: undefined, defaultSelectedRowKeys: ['ada'] } })
+    checked = wrapper.findAll('tbody input[type="checkbox"]')
+      .map((input) => (input.element as HTMLInputElement).checked)
+    expect(checked).toEqual([false, false, false])
+  })
+
   it('supports radio row selection', async () => {
     const wrapper = mount(Table, {
       props: {
@@ -488,6 +528,21 @@ describe('Table', () => {
     expect(wrapper.find('tbody tr').text()).toContain('Ada')
     expect(wrapper.find('.aheart-pagination__page.is-active').text()).toBe('1')
     expect(wrapper.emitted('change')?.[0]?.[0]).toMatchObject({ current: 2, pageSize: 1 })
+  })
+
+  it('keeps the last accepted page when the parent releases pagination control', async () => {
+    const wrapper = mount(Table, {
+      props: {
+        columns,
+        dataSource,
+        pagination: { current: 2, defaultCurrent: 1, pageSize: 1 }
+      }
+    })
+    expect(wrapper.find('tbody tr').text()).toContain('Grace')
+
+    await wrapper.setProps({ pagination: { defaultCurrent: 1, pageSize: 1 } })
+    expect(wrapper.find('tbody tr').text()).toContain('Grace')
+    expect(wrapper.find('.aheart-pagination__page.is-active').text()).toBe('2')
   })
 
   it('renders server-provided page records without slicing them a second time', () => {

--- a/packages/components/src/table/table.vue
+++ b/packages/components/src/table/table.vue
@@ -122,9 +122,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, ref, useId, watch, type PropType, type VNodeChild } from 'vue'
+import { computed, defineComponent, ref, watch, type PropType, type VNodeChild } from 'vue'
 import { resolveConfigValue, useAheartConfig } from '../config'
 import APagination from '../pagination'
+import { useControllableState } from '../utils/use-controllable-state'
+import { useStableId } from '../utils/use-stable-id'
 import {
   tableEmits,
   tableProps,
@@ -171,14 +173,31 @@ interface InternalSortState {
   order?: TableSortOrder
 }
 
-const innerSelectedRowKeys = ref<TableKey[]>(props.rowSelection?.defaultSelectedRowKeys ?? [])
-const innerExpandedRowKeys = ref<TableKey[]>(props.expandable?.defaultExpandedRowKeys ?? [])
-const innerCurrent = ref(props.pagination && typeof props.pagination === 'object' ? (props.pagination.defaultCurrent ?? props.pagination.current ?? 1) : 1)
+const hasOwn = (value: object | undefined, key: string) => Boolean(value && Object.prototype.hasOwnProperty.call(value, key))
+const selectedState = useControllableState<TableKey[]>({
+  controlled: () => props.rowSelection?.selectedRowKeys,
+  isControlled: () => hasOwn(props.rowSelection, 'selectedRowKeys'),
+  defaultValue: () => [...(props.rowSelection?.defaultSelectedRowKeys ?? [])],
+  onChange: (keys) => emit('update:selectedRowKeys', keys ?? [])
+})
+const expandedState = useControllableState<TableKey[]>({
+  controlled: () => props.expandable?.expandedRowKeys,
+  isControlled: () => hasOwn(props.expandable, 'expandedRowKeys'),
+  defaultValue: () => [...(props.expandable?.defaultExpandedRowKeys ?? [])],
+  onChange: (keys) => emit('update:expandedRowKeys', keys ?? [])
+})
+const currentState = useControllableState<number>({
+  controlled: () => props.pagination && typeof props.pagination === 'object' ? props.pagination.current : undefined,
+  isControlled: () => Boolean(props.pagination && typeof props.pagination === 'object' && hasOwn(props.pagination, 'current')),
+  defaultValue: () => props.pagination && typeof props.pagination === 'object'
+    ? props.pagination.defaultCurrent ?? props.pagination.current ?? 1
+    : 1
+})
 const innerSort = ref<InternalSortState>({})
 const innerFilters = ref<TableFilters>({})
 const hasInitializedSort = ref(false)
 const initializedFilterKeys = ref(new Set<string>())
-const radioName = `aheart-table-selection-${useId().replace(/[^a-zA-Z0-9_-]/g, '-')}`
+const radioName = useStableId(undefined, 'aheart-table-selection').value
 
 const normalizedColumns = computed(() => (props.columns ?? []).filter((column) => !column.hidden))
 const normalizedData = computed(() => props.dataSource ?? [])
@@ -188,8 +207,8 @@ const hasSelection = computed(() => Boolean(props.rowSelection))
 const hasExpandable = computed(() => Boolean(props.expandable?.expandedRowRender))
 const selectionType = computed(() => props.rowSelection?.type ?? 'checkbox')
 const isSelectionDisabled = computed(() => isDisabled.value || Boolean(props.rowSelection?.disabled))
-const selectedKeys = computed(() => props.rowSelection?.selectedRowKeys ?? innerSelectedRowKeys.value)
-const expandedKeys = computed(() => props.expandable?.expandedRowKeys ?? innerExpandedRowKeys.value)
+const selectedKeys = computed(() => selectedState.state.value ?? [])
+const expandedKeys = computed(() => expandedState.state.value ?? [])
 const resolvedEmptyText = computed<TableRenderable>(() =>
   hasRenderableContent(props.emptyText)
     ? props.emptyText
@@ -202,7 +221,7 @@ const pageSize = computed(() => {
   const value = paginationConfig.value.pageSize ?? paginationConfig.value.defaultPageSize ?? 10
   return Number.isFinite(value) && value > 0 ? Math.max(1, Math.trunc(value)) : 1
 })
-const rawCurrentPage = computed(() => paginationConfig.value.current ?? innerCurrent.value)
+const rawCurrentPage = computed(() => currentState.state.value ?? 1)
 const paginationTotal = computed(() => paginationConfig.value.total ?? sortedData.value.length)
 const pageCount = computed(() => Math.max(1, Math.ceil(Math.max(0, paginationTotal.value) / pageSize.value)))
 const currentPage = computed(() => Math.min(Math.max(rawCurrentPage.value, 1), pageCount.value))
@@ -272,15 +291,6 @@ const pagedRows = computed(() => {
 })
 
 watch(
-  () => props.rowSelection?.defaultSelectedRowKeys,
-  (keys) => {
-    if (!props.rowSelection?.selectedRowKeys && keys) {
-      innerSelectedRowKeys.value = keys
-    }
-  }
-)
-
-watch(
   normalizedColumns,
   (columns) => {
     if (!hasInitializedSort.value) {
@@ -322,8 +332,8 @@ watch(
 )
 
 watch(pageCount, (count) => {
-  if (paginationConfig.value.current === undefined && innerCurrent.value > count) {
-    innerCurrent.value = count
+  if (!currentState.isControlled.value && (currentState.state.value ?? 1) > count) {
+    currentState.setState(count)
   }
 })
 
@@ -523,9 +533,7 @@ const toggleFilter = (column: TableColumn, value: TableFilterValue) => {
 }
 
 const resetInnerCurrent = () => {
-  if (paginationConfig.value.current === undefined) {
-    innerCurrent.value = 1
-  }
+  currentState.setState(1)
 }
 
 const isSelected = (key: TableKey) => selectedKeys.value.includes(key)
@@ -543,11 +551,7 @@ const toggleSelection = (record: TableRecord, key: TableKey, checked: boolean) =
       ? Array.from(new Set([...selectedKeys.value, key]))
       : selectedKeys.value.filter((currentKey) => currentKey !== key)
 
-  if (props.rowSelection?.selectedRowKeys === undefined) {
-    innerSelectedRowKeys.value = nextKeys
-  }
-
-  emit('update:selectedRowKeys', nextKeys)
+  selectedState.setState(nextKeys)
   emit('select', key, checked, record, nextKeys)
 }
 
@@ -562,18 +566,12 @@ const toggleExpand = (record: TableRecord, key: TableKey) => {
   const nextExpanded = !isExpanded(key)
   const nextKeys = nextExpanded ? [...expandedKeys.value, key] : expandedKeys.value.filter((currentKey) => currentKey !== key)
 
-  if (props.expandable?.expandedRowKeys === undefined) {
-    innerExpandedRowKeys.value = nextKeys
-  }
-
-  emit('update:expandedRowKeys', nextKeys)
+  expandedState.setState(nextKeys)
   emit('expand', nextExpanded, record, key)
 }
 
 const handlePageChange = (current: number, nextPageSize: number) => {
-  if (paginationConfig.value.current === undefined) {
-    innerCurrent.value = current
-  }
+  currentState.setState(current)
 
   emitTableChange('paginate', current, nextPageSize, activeFilters.value, activeSort.value)
 }

--- a/packages/components/src/time-picker/time-picker.vue
+++ b/packages/components/src/time-picker/time-picker.vue
@@ -119,14 +119,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, isVNode, nextTick, onBeforeUnmount, ref, toRaw, useAttrs, useId, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
+import { computed, defineComponent, h, isVNode, nextTick, onBeforeUnmount, ref, toRaw, useAttrs, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
 import { resolveConfigValue, useAheartConfig, zhCN } from '../config'
 import AIcon from '../icon/icon.vue'
 import { createTimeOptions, formatTimeValue, parseTimeValue, type PickerTimeParts } from '../picker-core/time'
 import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import { timePickerEmits, timePickerProps, type DisabledTimeConfig } from './types'
 import './style.css'
@@ -151,13 +153,23 @@ const minuteColumnRef = ref<HTMLElement | null>(null)
 const secondColumnRef = ref<HTMLElement | null>(null)
 const periodColumnRef = ref<HTMLElement | null>(null)
 const activeColumn = ref<TimeColumn>('hour')
-const internalValue = ref(props.defaultValue)
-const internalOpen = ref(props.defaultOpen)
-const instanceId = useId().replace(/:/g, '')
-const panelId = `aheart-time-${instanceId}-panel`
+const instanceId = useStableId(undefined, 'aheart-time').value
+const panelId = `${instanceId}-panel`
 const isValueControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
 const isFormatProvided = usePropPresence('format')
+const valueState = useControllableState<string>({
+  controlled: () => props.modelValue,
+  isControlled: isValueControlled,
+  defaultValue: () => props.defaultValue,
+  onChange: (value) => emit('update:modelValue', value)
+})
+const openState = useControllableState<boolean>({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => emit('openChange', Boolean(open))
+})
 const ARenderNode = defineComponent({
   name: 'ATimePickerRenderNode',
   props: { node: { type: null as unknown as PropType<VNodeChild | Component>, default: undefined } },
@@ -169,8 +181,8 @@ const ARenderNode = defineComponent({
     }
   }
 })
-const mergedValue = computed(() => isValueControlled.value ? props.modelValue : internalValue.value)
-const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value))
+const mergedValue = valueState.state
+const mergedOpen = computed(() => Boolean(openState.state.value))
 const resolvedLocale = computed(() => ({ ...zhCN.timePicker, ...config.value.locale?.timePicker }) as Required<NonNullable<typeof zhCN.timePicker>>)
 const resolvedPlaceholder = computed(() => props.placeholder ?? resolvedLocale.value.selectTime)
 const isDisabled = computed(() => resolveConfigValue(props.disabled, config.value.disabled, false))
@@ -299,8 +311,7 @@ const scrollSelectedOptionsIntoView = () => {
 }
 const requestOpen = (open: boolean) => {
   if (open && isInteractionDisabled.value) return
-  if (!isOpenControlled.value) internalOpen.value = open
-  emit('openChange', open)
+  openState.setState(open, { force: true })
   if (open) {
     syncDraft()
     activeColumn.value = 'hour'
@@ -309,8 +320,7 @@ const requestOpen = (open: boolean) => {
 const commitValue = (parts: TimeParts, close = true) => {
   if (isInteractionDisabled.value || isPartsDisabled(parts)) return false
   const value = formatTime(parts, props.valueFormat)
-  if (!isValueControlled.value) internalValue.value = value
-  emit('update:modelValue', value)
+  valueState.setState(value, { force: true })
   emit('change', value)
   if (isValueControlled.value && !props.needConfirm) syncDraft()
   if (close) requestOpen(false)
@@ -353,8 +363,7 @@ const selectNow = () => {
 }
 const clearValue = () => {
   if (isInteractionDisabled.value) return
-  if (!isValueControlled.value) internalValue.value = undefined
-  emit('update:modelValue', undefined)
+  valueState.setState(undefined, { force: true })
   emit('change', undefined)
   emit('clear')
   requestOpen(false)
@@ -458,7 +467,4 @@ watch(mergedValue, syncDraft)
 watch(mergedOpen, (open) => {
   if (open) void nextTick(scrollSelectedOptionsIntoView)
 }, { immediate: true })
-watch(() => props.defaultOpen, (open) => {
-  if (!isOpenControlled.value) internalOpen.value = open
-})
 </script>

--- a/packages/components/src/time-picker/time-range-picker.vue
+++ b/packages/components/src/time-picker/time-range-picker.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, isVNode, nextTick, onBeforeUnmount, ref, toRaw, useId, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
+import { computed, defineComponent, h, isVNode, nextTick, onBeforeUnmount, ref, toRaw, useSlots, watch, type Component, type PropType, type VNodeChild } from 'vue'
 import { resolveConfigValue, useAheartConfig, zhCN } from '../config'
 import AIcon from '../icon/icon.vue'
 import { createTimeOptions, formatTimeValue, parseTimeValue, timePartsToSeconds, type PickerTimeParts } from '../picker-core/time'
@@ -62,7 +62,9 @@ import type { PickerDisabledTimeConfig, RangePickerPart, RangePickerValue } from
 import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import { timeRangePickerEmits, timeRangePickerProps } from './types'
 import './style.css'
@@ -80,15 +82,13 @@ const hourColumnRef = ref<HTMLElement | null>(null)
 const minuteColumnRef = ref<HTMLElement | null>(null)
 const secondColumnRef = ref<HTMLElement | null>(null)
 const periodColumnRef = ref<HTMLElement | null>(null)
-const internalValue = ref<RangePickerValue>(props.defaultValue ? [...props.defaultValue] as RangePickerValue : undefined)
-const internalOpen = ref(props.defaultOpen)
 const activePart = ref<RangePickerPart>('start')
 type TimeColumn = 'hour' | 'minute' | 'second' | 'period'
 const activeColumn = ref<TimeColumn>('hour')
 const draftValue = ref<RangePickerValue>()
 const draftParts = ref<[PickerTimeParts, PickerTimeParts]>([{ hour: 0, minute: 0, second: 0 }, { hour: 0, minute: 0, second: 0 }])
 const liveMessage = ref('')
-const panelId = `aheart-time-range-${useId().replace(/:/g, '')}-panel`
+const panelId = `${useStableId(undefined, 'aheart-time-range').value}-panel`
 const instanceId = panelId.replace('-panel', '')
 const partPanelId = `${instanceId}-part-panel`
 const startTabId = `${instanceId}-start-tab`
@@ -96,6 +96,18 @@ const endTabId = `${instanceId}-end-tab`
 const isValueControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
 const isFormatProvided = usePropPresence('format')
+const valueState = useControllableState<RangePickerValue>({
+  controlled: () => props.modelValue,
+  isControlled: isValueControlled,
+  defaultValue: () => props.defaultValue ? [...props.defaultValue] as RangePickerValue : undefined,
+  onChange: (value) => emit('update:modelValue', value)
+})
+const openState = useControllableState<boolean>({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => emit('openChange', Boolean(open))
+})
 
 const ARenderNode = defineComponent({
   name: 'ATimeRangePickerRenderNode',
@@ -109,8 +121,8 @@ const ARenderNode = defineComponent({
   }
 })
 
-const mergedValue = computed<RangePickerValue>(() => isValueControlled.value ? props.modelValue : internalValue.value)
-const mergedOpen = computed(() => Boolean(isOpenControlled.value ? props.open : internalOpen.value))
+const mergedValue = valueState.state
+const mergedOpen = computed(() => Boolean(openState.state.value))
 const resolvedLocale = computed(() => ({ ...zhCN.timePicker, ...config.value.locale?.timePicker }) as Required<NonNullable<typeof zhCN.timePicker>>)
 const resolvedPlaceholders = computed<[string, string]>(() => props.placeholder ?? [resolvedLocale.value.startTime, resolvedLocale.value.endTime])
 const isDisabled = computed(() => resolveConfigValue(props.disabled, config.value.disabled, false))
@@ -244,8 +256,7 @@ const handleColumnScroll = (column: 'hour' | 'minute' | 'second', event: Event) 
 const commitRange = (value: RangePickerValue, close = true) => {
   if (isInteractionDisabled.value) return false
   if (!value) {
-    if (!isValueControlled.value) internalValue.value = undefined
-    emit('update:modelValue', undefined)
+    valueState.setState(undefined, { force: true })
     emit('change', undefined)
     if (close) requestOpen(false)
     return true
@@ -256,8 +267,7 @@ const commitRange = (value: RangePickerValue, close = true) => {
     const parts = parseTime(endpoint)
     if (parts && isPartsDisabled(parts, index === 0 ? 'start' : 'end')) return false
   }
-  if (!isValueControlled.value) internalValue.value = [...normalized] as RangePickerValue
-  emit('update:modelValue', normalized)
+  valueState.setState([...normalized] as RangePickerValue, { force: true })
   emit('change', normalized)
   if (isValueControlled.value && !props.needConfirm) syncDraft()
   if (close) requestOpen(false)
@@ -344,8 +354,7 @@ const panelStyle = computed(() => floatingPosition.popupStyle.value)
 const requestOpen = (open: boolean) => {
   if (open && isInteractionDisabled.value) return
   const wasOpen = mergedOpen.value
-  if (!isOpenControlled.value) internalOpen.value = open
-  emit('openChange', open)
+  openState.setState(open, { force: true })
   if (open && !wasOpen) syncDraft()
 }
 const updateLiveMessage = (value: RangePickerValue) => {

--- a/packages/components/src/tree-select/tree-select.vue
+++ b/packages/components/src/tree-select/tree-select.vue
@@ -71,6 +71,7 @@ import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { usePropPresence } from '../utils/use-prop-presence'
+import { useControllableState } from '../utils/use-controllable-state'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import './style.css'
 
@@ -113,14 +114,30 @@ const emit = defineEmits<{
 const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
-const innerOpen = ref(props.defaultOpen)
 const searchText = ref('')
-const innerValue = ref<TreeSelectValue>(props.defaultValue)
 const isControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
-const mergedOpen = computed(() => isOpenControlled.value ? props.open : innerOpen.value)
 const resolvedAriaLabelledby = computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs['aria-labelledby'] as string | undefined)
-const mergedValue = computed(() => isControlled.value ? props.modelValue : innerValue.value)
+const openState = useControllableState({
+  controlled: () => props.open,
+  isControlled: isOpenControlled,
+  defaultValue: () => props.defaultOpen,
+  onChange: (open) => {
+    const nextOpen = Boolean(open)
+    emit('openChange', nextOpen)
+  }
+})
+const valueState = useControllableState<TreeSelectValue>({
+  controlled: () => props.modelValue,
+  isControlled,
+  defaultValue: () => props.defaultValue,
+  onChange: (value) => {
+    emit('update:modelValue', value)
+    emit('change', value)
+  }
+})
+const mergedOpen = computed(() => Boolean(openState.state.value))
+const mergedValue = valueState.state
 const selectedKeys = computed<TreeKey[]>(() => Array.isArray(mergedValue.value) ? mergedValue.value : mergedValue.value === undefined ? [] : [mergedValue.value])
 const flattenNodes = (nodes: TreeNodeData[]): TreeNodeData[] => nodes.flatMap((node) => [node, ...flattenNodes(node.children ?? [])])
 const displayLabel = computed(() => selectedKeys.value
@@ -152,13 +169,10 @@ const toggleOpen = () => {
 }
 const requestOpen = (open: boolean) => {
   if (props.disabled) return
-  if (!isOpenControlled.value) innerOpen.value = open
-  emit('openChange', open)
+  openState.setState(open, { force: true })
 }
 const emitValue = (value: TreeSelectValue) => {
-  if (!isControlled.value) innerValue.value = value
-  emit('update:modelValue', value)
-  emit('change', value)
+  valueState.setState(value, { force: true })
 }
 const handleSelect = (keys: TreeKey[]) => {
   const value: TreeSelectValue = props.multiple ? keys : keys[0]
@@ -219,7 +233,4 @@ useFloatingDismiss({
   onDismiss: () => requestOpen(false)
 })
 
-watch(() => props.defaultOpen, (open) => {
-  if (!isOpenControlled.value) innerOpen.value = open
-})
 </script>

--- a/packages/components/src/upload/__tests__/upload.test.ts
+++ b/packages/components/src/upload/__tests__/upload.test.ts
@@ -61,6 +61,46 @@ describe('Upload', () => {
     expect(wrapper.findAll('.aheart-upload__item')).toHaveLength(0)
   })
 
+  it('treats an explicitly undefined fileList as controlled', async () => {
+    const wrapper = mount(Upload, { props: { fileList: undefined, defaultFileList: [{ uid: 'default', name: 'default.txt' }] } })
+    expect(wrapper.findAll('.aheart-upload__item')).toHaveLength(0)
+
+    await selectFiles(wrapper.find('input[type="file"]'), [createFile('requested.txt')])
+    expect(wrapper.emitted('update:fileList')?.at(-1)?.[0]).toMatchObject([{ name: 'requested.txt' }])
+    expect(wrapper.findAll('.aheart-upload__item')).toHaveLength(0)
+  })
+
+  it('uses defaultFileList only for initialization', async () => {
+    const wrapper = mount(Upload, { props: { defaultFileList: [{ uid: 'first', name: 'first.txt' }] } })
+    await wrapper.find('.aheart-upload__remove').trigger('click')
+    expect(wrapper.findAll('.aheart-upload__item')).toHaveLength(0)
+
+    await wrapper.setProps({ defaultFileList: [{ uid: 'second', name: 'second.txt' }] })
+    expect(wrapper.findAll('.aheart-upload__item')).toHaveLength(0)
+  })
+
+  it('rebases an async beforeUpload result onto the latest controlled fileList', async () => {
+    let allowUpload: (() => void) | undefined
+    const beforeUpload = () => new Promise<boolean>((resolve) => {
+      allowUpload = () => resolve(false)
+    })
+    const wrapper = mount(Upload, {
+      props: {
+        fileList: [{ uid: 'owner-a', name: 'owner-a.txt' }],
+        beforeUpload
+      }
+    })
+
+    const change = selectFiles(wrapper.find('input[type="file"]'), [createFile('new.txt')])
+    await vi.waitFor(() => expect(allowUpload).toBeTypeOf('function'))
+    await wrapper.setProps({ fileList: [{ uid: 'owner-b', name: 'owner-b.txt' }] })
+    allowUpload?.()
+    await change
+
+    expect(wrapper.emitted('update:fileList')?.at(-1)?.[0].map((file: { name: string }) => file.name))
+      .toEqual(['owner-b.txt', 'new.txt'])
+  })
+
   it('allows manual upload after beforeUpload returns false', async () => {
     const customRequest = vi.fn(async ({ onSuccess }: { onSuccess: (response?: unknown) => void }) => onSuccess())
     const wrapper = mount(Upload, { props: { beforeUpload: () => false, customRequest } })

--- a/packages/components/src/upload/upload.vue
+++ b/packages/components/src/upload/upload.vue
@@ -20,6 +20,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useAheartConfig } from '../config'
+import { useControllableState } from '../utils/use-controllable-state'
+import { usePropPresence } from '../utils/use-prop-presence'
 import type { UploadFile, UploadRequest } from './types'
 import './style.css'
 
@@ -48,21 +50,26 @@ const copy = computed(() => config.value.locale?.datePicker?.locale === 'en-US'
   ? { selectFile: 'Select file', upload: 'Upload', done: 'Done', failed: 'Failed', removeAction: 'Remove', remove: (name: string) => `Remove ${name}` }
   : { selectFile: '选择文件', upload: '上传', done: '已完成', failed: '上传失败', removeAction: '移除', remove: (name: string) => `移除 ${name}` })
 
-const internalFileList = ref<UploadFile[]>([...props.defaultFileList])
-const mergedFileList = computed(() => props.fileList ?? internalFileList.value)
+const isFileListControlled = usePropPresence('fileList', 'file-list')
+const fileListState = useControllableState<UploadFile[]>({
+  controlled: () => props.fileList,
+  isControlled: isFileListControlled,
+  defaultValue: () => [...props.defaultFileList],
+  onChange: (files) => emit('update:fileList', files ?? [])
+})
+const mergedFileList = computed(() => fileListState.state.value ?? [])
 const readyFiles = computed(() => mergedFileList.value.filter((file) => file.status === 'ready'))
 const latestFileList = ref<UploadFile[]>([...(props.fileList ?? props.defaultFileList)])
 let uid = 0
 const activeUploadUids = new Set<string>()
 
 watch(() => props.fileList, (fileList) => {
-  if (fileList !== undefined) latestFileList.value = [...fileList]
+  if (isFileListControlled.value) latestFileList.value = [...(fileList ?? [])]
 }, { deep: true })
 
 const updateFileList = (files: UploadFile[]) => {
   latestFileList.value = files
-  if (props.fileList === undefined) internalFileList.value = files
-  emit('update:fileList', files)
+  fileListState.setState(files)
   emit('change', files)
 }
 const replaceFile = (file: UploadFile) => {
@@ -118,14 +125,16 @@ const handleChange = async (event: Event) => {
   if (props.disabled) return
   const files = Array.from((event.target as HTMLInputElement).files ?? [])
   ;(event.target as HTMLInputElement).value = ''
-  let nextFiles = props.fileList === undefined ? latestFileList.value : [...props.fileList]
+  let nextFiles = isFileListControlled.value ? [...(props.fileList ?? [])] : latestFileList.value
   latestFileList.value = nextFiles
-  const remaining = Math.max(0, props.maxCount - nextFiles.length)
 
-  for (const rawFile of files.slice(0, remaining)) {
+  for (const rawFile of files) {
+    if (nextFiles.length >= props.maxCount) break
     const uploadFile = toUploadFile(rawFile)
     const shouldUpload = await props.beforeUpload?.(rawFile, [...nextFiles, uploadFile])
-    nextFiles = [...nextFiles, uploadFile]
+    const currentFiles = isFileListControlled.value ? [...(props.fileList ?? [])] : latestFileList.value
+    if (currentFiles.length >= props.maxCount) continue
+    nextFiles = [...currentFiles, uploadFile]
     updateFileList(nextFiles)
     if (shouldUpload !== false) nextFiles = await upload(uploadFile, nextFiles)
   }

--- a/packages/components/src/utils/__tests__/use-async-task.test.ts
+++ b/packages/components/src/utils/__tests__/use-async-task.test.ts
@@ -1,0 +1,112 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { useAsyncTask } from '../use-async-task'
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+const mountTask = <TArgs extends unknown[], TResult>(
+  task: (context: { signal: AbortSignal; requestId: number }, ...args: TArgs) => Promise<TResult>,
+  options = {}
+) => {
+  let api!: ReturnType<typeof useAsyncTask<TArgs, TResult>>
+  const wrapper = mount(defineComponent({
+    setup() {
+      api = useAsyncTask(task, options)
+      return () => h('div')
+    }
+  }))
+  return { api, wrapper }
+}
+
+describe('useAsyncTask', () => {
+  it('aborts the previous request and only commits the latest result', async () => {
+    const first = deferred<string>()
+    const second = deferred<string>()
+    const signals: AbortSignal[] = []
+    const { api, wrapper } = mountTask(async ({ signal }, value: string) => {
+      signals.push(signal)
+      return value === 'first' ? first.promise : second.promise
+    })
+
+    const firstRun = api.run('first')
+    const secondRun = api.run('second')
+    expect(signals[0].aborted).toBe(true)
+    second.resolve('latest')
+    expect(await secondRun).toBe('latest')
+    first.resolve('stale')
+    expect(await firstRun).toBeUndefined()
+    expect(api.data.value).toBe('latest')
+    expect(api.status.value).toBe('success')
+    wrapper.unmount()
+  })
+
+  it('recovers from an error and clears it on the next run', async () => {
+    const onError = vi.fn()
+    let attempt = 0
+    const { api, wrapper } = mountTask(async () => {
+      attempt += 1
+      if (attempt === 1) throw new Error('failed')
+      return 'recovered'
+    }, { onError })
+
+    await expect(api.run()).resolves.toBeUndefined()
+    expect(api.status.value).toBe('error')
+    expect(api.error.value).toEqual(new Error('failed'))
+    expect(onError).toHaveBeenCalledTimes(1)
+
+    await expect(api.run()).resolves.toBe('recovered')
+    expect(api.status.value).toBe('success')
+    expect(api.error.value).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('ignores a late result after an explicit abort', async () => {
+    const request = deferred<string>()
+    const { api, wrapper } = mountTask(async () => request.promise)
+    const running = api.run()
+    expect(api.isPending.value).toBe(true)
+
+    api.abort()
+    request.resolve('late')
+    expect(await running).toBeUndefined()
+    expect(api.status.value).toBe('idle')
+    expect(api.data.value).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('aborts the active task when its owner unmounts', async () => {
+    const request = deferred<string>()
+    let signal!: AbortSignal
+    const { api, wrapper } = mountTask(async (context) => {
+      signal = context.signal
+      return request.promise
+    })
+    void api.run()
+    await nextTick()
+
+    wrapper.unmount()
+    expect(signal.aborted).toBe(true)
+    request.resolve('ignored')
+  })
+
+  it('reset clears committed data and invalidates pending work', async () => {
+    const { api, wrapper } = mountTask(async (_context, value: string) => value)
+    await api.run('ready')
+    expect(api.data.value).toBe('ready')
+
+    api.reset()
+    expect(api.status.value).toBe('idle')
+    expect(api.data.value).toBeUndefined()
+    expect(api.error.value).toBeUndefined()
+    wrapper.unmount()
+  })
+})

--- a/packages/components/src/utils/__tests__/use-collection.test.ts
+++ b/packages/components/src/utils/__tests__/use-collection.test.ts
@@ -1,0 +1,37 @@
+import { effectScope } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useCollection } from '../use-collection'
+
+describe('useCollection', () => {
+  it('keeps registration order and stable generated keys', () => {
+    const scope = effectScope()
+    const result = scope.run(() => useCollection())!
+    const first = result.register({ element: document.createElement('button') })
+    const second = result.register({ key: 'second', element: document.createElement('button') })
+
+    expect(first.key).toBeTruthy()
+    expect(result.items.value.map((item) => item.key)).toEqual([first.key, 'second'])
+    const replacement = document.createElement('button')
+    result.register({ key: 'second', element: replacement })
+    expect(result.items.value.map((item) => item.key)).toEqual([first.key, 'second'])
+    expect(result.getItem('second')?.element).toBe(replacement)
+    result.unregister(first.key)
+    expect(result.items.value.map((item) => item.key)).toEqual(['second'])
+    second.unregister()
+    expect(result.items.value).toHaveLength(0)
+    scope.stop()
+  })
+
+  it('updates metadata and filters visible and enabled items', () => {
+    const result = useCollection()
+    result.register({ key: 'a', element: document.createElement('button'), visible: false })
+    result.register({ key: 'b', element: document.createElement('button'), disabled: true })
+    result.register({ key: 'c', element: document.createElement('button') })
+
+    result.update('a', { visible: true })
+    expect(result.isVisible('a')).toBe(true)
+    expect(result.isDisabled('b')).toBe(true)
+    expect(result.getVisibleItems().map((item) => item.key)).toEqual(['a', 'b', 'c'])
+    expect(result.getEnabledItems().map((item) => item.key)).toEqual(['a', 'c'])
+  })
+})

--- a/packages/components/src/utils/__tests__/use-controllable-state.test.ts
+++ b/packages/components/src/utils/__tests__/use-controllable-state.test.ts
@@ -1,0 +1,102 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { useControllableState } from '../use-controllable-state'
+
+describe('useControllableState', () => {
+  it('uses the default only to initialize uncontrolled state', async () => {
+    const defaultValue = ref('first')
+    const Fixture = defineComponent({
+      setup() {
+        const state = useControllableState({ defaultValue })
+        return () => h('button', { onClick: () => state.setState('next') }, state.state.value)
+      }
+    })
+    const wrapper = mount(Fixture)
+
+    expect(wrapper.text()).toBe('first')
+    defaultValue.value = 'changed default'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toBe('first')
+    await wrapper.trigger('click')
+    expect(wrapper.text()).toBe('next')
+  })
+
+  it('reads controlled values and does not drift when the owner rejects an update', async () => {
+    const controlled = ref('owner')
+    const onChange = vi.fn()
+    let exposed: ReturnType<typeof useControllableState<string>>
+    const Fixture = defineComponent({
+      setup() {
+        exposed = useControllableState({ controlled, defaultValue: 'fallback', onChange })
+        return () => h('span', exposed.state.value)
+      }
+    })
+    const wrapper = mount(Fixture)
+
+    expect(wrapper.text()).toBe('owner')
+    exposed!.setState('requested')
+    await wrapper.vm.$nextTick()
+    expect(onChange).toHaveBeenCalledWith('requested')
+    expect(wrapper.text()).toBe('owner')
+    controlled.value = 'accepted'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toBe('accepted')
+  })
+
+  it('treats an explicitly undefined controlled ref as controlled', () => {
+    const controlled = ref<string | undefined>(undefined)
+    const onChange = vi.fn()
+    let exposed: ReturnType<typeof useControllableState<string | undefined>>
+    const Fixture = defineComponent({
+      setup() {
+        exposed = useControllableState({ controlled, defaultValue: 'ignored', onChange })
+        return () => h('span', exposed.state.value ?? 'empty')
+      }
+    })
+    const wrapper = mount(Fixture)
+
+    expect(exposed!.isControlled.value).toBe(true)
+    expect(wrapper.text()).toBe('empty')
+    exposed!.setState('requested')
+    expect(onChange).toHaveBeenCalledWith('requested')
+    expect(wrapper.text()).toBe('empty')
+  })
+
+  it('deduplicates updates with Object.is', () => {
+    const state = useControllableState({ defaultValue: NaN, onChange: vi.fn() })
+    expect(state.setState(NaN)).toBe(false)
+    expect(state.state.value).toBeNaN()
+    expect(state.setState(-0)).toBe(true)
+    expect(state.setState(0)).toBe(true)
+    expect(state.setState(0, { force: true })).toBe(true)
+  })
+
+  it('supports an owner taking and releasing control after mount', async () => {
+    const controlled = ref<string | undefined>(undefined)
+    const isControlled = ref(false)
+    let exposed: ReturnType<typeof useControllableState<string>>
+    const Fixture = defineComponent({
+      setup() {
+        exposed = useControllableState({ controlled, isControlled, defaultValue: 'local' })
+        return () => h('span', exposed.state.value)
+      }
+    })
+    const wrapper = mount(Fixture)
+
+    exposed!.setState('local update')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toBe('local update')
+
+    controlled.value = 'owner'
+    isControlled.value = true
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toBe('owner')
+    exposed!.setState('rejected')
+    expect(wrapper.text()).toBe('owner')
+
+    isControlled.value = false
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toBe('owner')
+  })
+})

--- a/packages/components/src/utils/__tests__/use-roving-focus.test.ts
+++ b/packages/components/src/utils/__tests__/use-roving-focus.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useCollection } from '../use-collection'
+import { useRovingFocus } from '../use-roving-focus'
+
+describe('useRovingFocus', () => {
+  it('moves by arrows, skips disabled items, and loops', () => {
+    const collection = useCollection()
+    const elements = ['a', 'b', 'c'].map(() => document.createElement('button'))
+    collection.register({ key: 'a', element: elements[0] })
+    collection.register({ key: 'b', element: elements[1], disabled: true })
+    collection.register({ key: 'c', element: elements[2] })
+    const focus = useRovingFocus({ collection })
+
+    expect(focus.getNextKey('a', 'ArrowRight')).toBe('c')
+    expect(focus.getNextKey('c', 'ArrowRight')).toBe('a')
+    expect(focus.getNextKey(undefined, 'ArrowDown')).toBe('a')
+    expect(focus.getNextKey(undefined, 'ArrowUp')).toBe('c')
+  })
+
+  it('handles Home/End and focuses through the element ownerDocument', () => {
+    const ownerDocument = document.implementation.createHTMLDocument('embedded')
+    const collection = useCollection<HTMLButtonElement>()
+    const one = ownerDocument.createElement('button')
+    const two = ownerDocument.createElement('button')
+    ownerDocument.body.append(one, two)
+    const focusSpy = vi.spyOn(two, 'focus')
+    collection.register({ key: 'one', element: one })
+    collection.register({ key: 'two', element: two })
+    const focus = useRovingFocus({ collection, loop: false })
+    expect(focus.getNextKey('two', 'Home')).toBe('one')
+    expect(focus.getNextKey('one', 'End')).toBe('two')
+    expect(focus.focus('two')).toBe(true)
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('respects orientation, non-looping boundaries, and preventDefault', () => {
+    const collection = useCollection<HTMLButtonElement>()
+    collection.register({ key: 'one', element: document.createElement('button') })
+    collection.register({ key: 'two', element: document.createElement('button') })
+    const focus = useRovingFocus({ collection, orientation: 'vertical', loop: false })
+
+    const ignored = new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true })
+    expect(focus.onKeydown(ignored, 'one')).toBe(false)
+    expect(ignored.defaultPrevented).toBe(false)
+
+    const boundary = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true })
+    expect(focus.onKeydown(boundary, 'one')).toBe(false)
+    expect(boundary.defaultPrevented).toBe(false)
+
+    const handled = new KeyboardEvent('keydown', { key: 'ArrowDown', cancelable: true })
+    expect(focus.onKeydown(handled, 'one')).toBe(true)
+    expect(handled.defaultPrevented).toBe(true)
+  })
+})

--- a/packages/components/src/utils/__tests__/use-stable-id.test.ts
+++ b/packages/components/src/utils/__tests__/use-stable-id.test.ts
@@ -1,0 +1,67 @@
+import { mount } from '@vue/test-utils'
+import { renderToString } from '@vue/server-renderer'
+import { createSSRApp, defineComponent, h, ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useStableId } from '../use-stable-id'
+
+describe('useStableId', () => {
+  it('uses an explicit id and reacts if the explicit source changes', async () => {
+    const explicitId = ref('provided-id')
+    const Fixture = defineComponent({
+      setup() {
+        const id = useStableId(explicitId)
+        return () => h('span', { id: id.value }, id.value)
+      }
+    })
+    const wrapper = mount(Fixture)
+    expect(wrapper.attributes('id')).toBe('provided-id')
+    explicitId.value = 'updated-id'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.attributes('id')).toBe('updated-id')
+  })
+
+  it('generates a stable prefixed id for one component instance', () => {
+    const Fixture = defineComponent({
+      setup() {
+        const first = useStableId(undefined, 'field')
+        const second = useStableId(undefined, 'field')
+        return () => h('span', { 'data-first': first.value, 'data-second': second.value })
+      }
+    })
+    const wrapper = mount(Fixture)
+    const first = wrapper.attributes('data-first')
+    const second = wrapper.attributes('data-second')
+    expect(first).toMatch(/^field-/)
+    expect(second).toMatch(/^field-/)
+    expect(first).not.toBe(second)
+    expect(wrapper.attributes('data-first')).toBe(first)
+  })
+
+  it('keeps generated ids prefixed across instances', () => {
+    const Fixture = defineComponent({
+      setup() {
+        const id = useStableId(undefined, 'control')
+        return () => h('span', { id: id.value })
+      }
+    })
+    const first = mount(Fixture)
+    const second = mount(Fixture)
+    expect(first.attributes('id')).toMatch(/^control-/)
+    expect(second.attributes('id')).toMatch(/^control-/)
+    expect(second.attributes('id')).toMatch(/^control-/)
+  })
+
+  it('generates the same safe id sequence for equivalent SSR app trees', async () => {
+    const Fixture = defineComponent({
+      setup() {
+        const id = useStableId(undefined, 'field')
+        return () => h('label', { for: id.value }, id.value)
+      }
+    })
+
+    const first = await renderToString(createSSRApp(Fixture))
+    const second = await renderToString(createSSRApp(Fixture))
+    expect(second).toBe(first)
+    expect(first).not.toContain(':')
+  })
+})

--- a/packages/components/src/utils/use-async-task.ts
+++ b/packages/components/src/utils/use-async-task.ts
@@ -1,0 +1,78 @@
+import { computed, onBeforeUnmount, readonly, shallowRef } from 'vue'
+
+export type AsyncTaskStatus = 'idle' | 'pending' | 'success' | 'error'
+
+export interface AsyncTaskContext {
+  signal: AbortSignal
+  requestId: number
+}
+
+export interface AsyncTaskOptions<TResult> {
+  onSuccess?: (result: TResult) => void
+  onError?: (error: unknown) => void
+}
+
+export const useAsyncTask = <TArgs extends unknown[], TResult>(
+  task: (context: AsyncTaskContext, ...args: TArgs) => Promise<TResult>,
+  options: AsyncTaskOptions<TResult> = {}
+) => {
+  const status = shallowRef<AsyncTaskStatus>('idle')
+  const data = shallowRef<TResult>()
+  const error = shallowRef<unknown>()
+  let requestId = 0
+  let controller: AbortController | undefined
+
+  const abort = () => {
+    requestId += 1
+    controller?.abort()
+    controller = undefined
+    if (status.value === 'pending') status.value = 'idle'
+  }
+
+  const reset = () => {
+    abort()
+    status.value = 'idle'
+    data.value = undefined
+    error.value = undefined
+  }
+
+  const run = async (...args: TArgs): Promise<TResult | undefined> => {
+    controller?.abort()
+    const currentController = new AbortController()
+    const currentRequestId = ++requestId
+    controller = currentController
+    status.value = 'pending'
+    error.value = undefined
+
+    try {
+      const result = await task({ signal: currentController.signal, requestId: currentRequestId }, ...args)
+      if (currentController.signal.aborted || currentRequestId !== requestId) return undefined
+
+      controller = undefined
+      data.value = result
+      status.value = 'success'
+      options.onSuccess?.(result)
+      return result
+    } catch (reason) {
+      if (currentController.signal.aborted || currentRequestId !== requestId) return undefined
+
+      controller = undefined
+      error.value = reason
+      status.value = 'error'
+      options.onError?.(reason)
+      return undefined
+    }
+  }
+
+  onBeforeUnmount(abort)
+
+  return {
+    status: readonly(status),
+    data: readonly(data),
+    error: readonly(error),
+    isPending: computed(() => status.value === 'pending'),
+    run,
+    abort,
+    reset
+  }
+}

--- a/packages/components/src/utils/use-collection.ts
+++ b/packages/components/src/utils/use-collection.ts
@@ -1,0 +1,76 @@
+import { shallowRef, type Ref } from 'vue'
+
+export interface CollectionItem<T extends HTMLElement = HTMLElement> {
+  key: string
+  element: T
+  disabled: boolean
+  visible: boolean
+}
+
+export interface CollectionRegistration<T extends HTMLElement = HTMLElement> {
+  key?: string
+  element: T
+  disabled?: boolean
+  visible?: boolean
+}
+
+export interface UseCollectionReturn<T extends HTMLElement = HTMLElement> {
+  items: Ref<CollectionItem<T>[]>
+  register: (item: CollectionRegistration<T>) => { key: string; unregister: () => void }
+  unregister: (key: string) => void
+  update: (key: string, patch: Partial<Pick<CollectionItem<T>, 'element' | 'disabled' | 'visible'>>) => void
+  getItem: (key: string) => CollectionItem<T> | undefined
+  getItems: () => CollectionItem<T>[]
+  getVisibleItems: () => CollectionItem<T>[]
+  getEnabledItems: () => CollectionItem<T>[]
+  isVisible: (key: string) => boolean
+  isDisabled: (key: string) => boolean
+}
+
+/** Internal ordered registry shared by composite components. */
+export function useCollection<T extends HTMLElement = HTMLElement>(): UseCollectionReturn<T> {
+  const items = shallowRef<CollectionItem<T>[]>([])
+  let nextKey = 0
+  const makeKey = () => `collection-item-${++nextKey}`
+  const getItem = (key: string) => items.value.find((item) => item.key === key)
+  const getItems = () => items.value.slice()
+  const getVisibleItems = () => items.value.filter((item) => item.visible)
+  const getEnabledItems = () => items.value.filter((item) => item.visible && !item.disabled)
+
+  const unregister = (key: string) => {
+    const index = items.value.findIndex((item) => item.key === key)
+    if (index >= 0) items.value = items.value.filter((item) => item.key !== key)
+  }
+
+  const register = (input: CollectionRegistration<T>) => {
+    const key = input.key || makeKey()
+    // Re-registration updates in place, preserving the original order.
+    const existing = getItem(key)
+    if (existing) {
+      items.value = items.value.map((item) => item.key === key
+        ? { ...item, element: input.element, disabled: !!input.disabled, visible: input.visible !== false }
+        : item)
+    } else {
+      items.value = [...items.value, { key, element: input.element, disabled: !!input.disabled, visible: input.visible !== false }]
+    }
+    return { key, unregister: () => unregister(key) }
+  }
+
+  const update = (key: string, patch: Partial<Pick<CollectionItem<T>, 'element' | 'disabled' | 'visible'>>) => {
+    const item = getItem(key)
+    if (item) items.value = items.value.map((entry) => entry.key === key ? { ...entry, ...patch } : entry)
+  }
+
+  return {
+    items,
+    register,
+    unregister,
+    update,
+    getItem,
+    getItems,
+    getVisibleItems,
+    getEnabledItems,
+    isVisible: (key) => getItem(key)?.visible === true,
+    isDisabled: (key) => getItem(key)?.disabled === true
+  }
+}

--- a/packages/components/src/utils/use-controllable-state.ts
+++ b/packages/components/src/utils/use-controllable-state.ts
@@ -1,0 +1,68 @@
+import { computed, ref, toValue, watch, type MaybeRefOrGetter, type Ref } from 'vue'
+
+export interface UseControllableStateOptions<T> {
+  /** Presence of this property opts into controlled mode, including an undefined value. */
+  controlled?: MaybeRefOrGetter<T | undefined>
+  /** Overrides property-presence detection when controlledness changes at runtime. */
+  isControlled?: MaybeRefOrGetter<boolean>
+  defaultValue?: MaybeRefOrGetter<T | undefined>
+  onChange?: (value: T | undefined) => void
+}
+
+export interface UseControllableStateReturn<T> {
+  state: Readonly<Ref<T | undefined>>
+  isControlled: Readonly<Ref<boolean>>
+  setState: (
+    next: T | undefined | ((current: T | undefined) => T | undefined),
+    options?: { force?: boolean }
+  ) => boolean
+}
+
+/**
+ * Small internal state bridge for controls that support both v-model and defaults.
+ * Controlled state is always read from its owner, so rejected update events cannot
+ * leave an optimistic value behind.
+ */
+export const useControllableState = <T>(
+  options: UseControllableStateOptions<T>
+): UseControllableStateReturn<T> => {
+  const controlledByPresence = Object.prototype.hasOwnProperty.call(options, 'controlled')
+  const isControlled = computed(() => options.isControlled === undefined
+    ? controlledByPresence
+    : toValue(options.isControlled))
+  const uncontrolled = ref(toValue(options.defaultValue)) as Ref<T | undefined>
+  const state = computed<T | undefined>(() => (
+    isControlled.value ? toValue(options.controlled) : uncontrolled.value
+  ))
+
+  watch(
+    [isControlled, () => toValue(options.controlled)],
+    ([controlled, value]) => {
+      if (controlled) uncontrolled.value = value
+    },
+    { flush: 'sync', immediate: true }
+  )
+
+  const setState = (
+    next: T | undefined | ((current: T | undefined) => T | undefined),
+    setOptions: { force?: boolean } = {}
+  ) => {
+    const value = typeof next === 'function'
+      ? (next as (current: T | undefined) => T | undefined)(state.value)
+      : next
+
+    // `force` preserves public event notifications for an explicit user action;
+    // the default path deduplicates state-only writes.
+    if (!setOptions.force && Object.is(value, state.value)) {
+      return false
+    }
+
+    if (!isControlled.value) {
+      uncontrolled.value = value
+    }
+    options.onChange?.(value)
+    return true
+  }
+
+  return { state, isControlled, setState }
+}

--- a/packages/components/src/utils/use-roving-focus.ts
+++ b/packages/components/src/utils/use-roving-focus.ts
@@ -1,0 +1,54 @@
+import { toValue, type MaybeRefOrGetter } from 'vue'
+import type { UseCollectionReturn } from './use-collection'
+
+export type RovingOrientation = 'horizontal' | 'vertical' | 'both'
+
+export interface UseRovingFocusOptions<T extends HTMLElement = HTMLElement> {
+  collection: UseCollectionReturn<T> | MaybeRefOrGetter<UseCollectionReturn<T>>
+  orientation?: RovingOrientation | MaybeRefOrGetter<RovingOrientation>
+  loop?: boolean | MaybeRefOrGetter<boolean>
+  preventDefault?: boolean | MaybeRefOrGetter<boolean>
+}
+
+export function useRovingFocus<T extends HTMLElement = HTMLElement>(options: UseRovingFocusOptions<T>) {
+  const collection = () => toValue(options.collection)
+  const orientation = () => toValue(options.orientation) ?? 'both'
+  const loops = () => toValue(options.loop) !== false
+  const shouldPrevent = () => toValue(options.preventDefault) !== false
+
+  const isDirection = (key: string) => {
+    if (orientation() === 'horizontal') return key === 'ArrowLeft' || key === 'ArrowRight'
+    if (orientation() === 'vertical') return key === 'ArrowUp' || key === 'ArrowDown'
+    return key.startsWith('Arrow')
+  }
+
+  const getNextKey = (currentKey: string | undefined, key: string) => {
+    const entries = collection().getEnabledItems()
+    if (!entries.length || (key !== 'Home' && key !== 'End' && !isDirection(key))) return undefined
+    if (key === 'Home') return entries[0].key
+    if (key === 'End') return entries[entries.length - 1].key
+    const forward = key === 'ArrowRight' || key === 'ArrowDown'
+    const index = entries.findIndex((item) => item.key === currentKey)
+    if (index < 0) return forward ? entries[0].key : entries[entries.length - 1].key
+    const next = index + (forward ? 1 : -1)
+    if (next >= 0 && next < entries.length) return entries[next].key
+    return loops() ? entries[(next + entries.length) % entries.length].key : undefined
+  }
+
+  const focus = (key: string, preventScroll = true) => {
+    const item = collection().getItem(key)
+    if (!item || !item.visible || item.disabled) return false
+    // HTMLElement.focus() is ownerDocument-safe, including adopted/iframe DOM.
+    item.element.focus({ preventScroll })
+    return true
+  }
+
+  const onKeydown = (event: KeyboardEvent, currentKey?: string) => {
+    const nextKey = getNextKey(currentKey, event.key)
+    if (!nextKey) return false
+    if (shouldPrevent()) event.preventDefault()
+    return focus(nextKey)
+  }
+
+  return { getNextKey, focus, onKeydown }
+}

--- a/packages/components/src/utils/use-stable-id.ts
+++ b/packages/components/src/utils/use-stable-id.ts
@@ -1,0 +1,10 @@
+import { computed, toValue, useId, type MaybeRefOrGetter, type ComputedRef } from 'vue'
+
+/** Returns an explicit id when supplied, otherwise a Vue SSR-safe generated id. */
+export const useStableId = (
+  explicitId?: MaybeRefOrGetter<string | undefined>,
+  prefix = 'aheart'
+): ComputedRef<string> => {
+  const generatedId = `${prefix}-${useId().replace(/[^a-zA-Z0-9_-]/g, '-')}`
+  return computed(() => toValue(explicitId) ?? generatedId)
+}

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -92,6 +92,9 @@ export default defineConfig(
                     index: 'src/index.ts',
                     'message/index': 'src/message/index.ts',
                     'utils/floating': 'src/utils/floating.ts',
+                    'utils/use-async-task': 'src/utils/use-async-task.ts',
+                    'utils/use-collection': 'src/utils/use-collection.ts',
+                    'utils/use-roving-focus': 'src/utils/use-roving-focus.ts',
                     'picker-core/index': 'src/picker-core/index.ts',
                     'date-picker/date-utils': 'src/date-picker/date-utils.ts'
                 },

--- a/scripts/state-kernel-build.test.mjs
+++ b/scripts/state-kernel-build.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const root = new URL('..', import.meta.url)
+const internalHelpers = [
+  'use-async-task',
+  'use-collection',
+  'use-controllable-state',
+  'use-roving-focus',
+  'use-stable-id'
+]
+
+test('D1 state helpers stay internal and ship paired ESM and CommonJS files', () => {
+  const publicEntry = readFileSync(new URL('./packages/components/src/index.ts', root), 'utf8')
+
+  for (const helper of internalHelpers) {
+    assert.doesNotMatch(publicEntry, new RegExp(`utils/${helper}`))
+    for (const format of ['es', 'lib']) {
+      assert.equal(existsSync(new URL(`./packages/components/${format}/utils/${helper}.d.ts`, root)), true)
+      assert.equal(existsSync(new URL(`./packages/components/${format}/utils/${helper}.js`, root)), true)
+    }
+  }
+})


### PR DESCRIPTION
## 产品任务

建立内部状态内核，并迁移 Select、Cascader、TreeSelect、Date/Range Picker、Time/Range Picker、Table、Upload；统一受控/非受控、SSR ID、异步任务、集合与 roving focus 契约，不改变公开 API。

## 实施结果

- 新增内部 useControllableState、useStableId、useAsyncTask、useCollection、useRovingFocus。
- 受控父层拒绝更新不漂移；运行时接管/释放保持最后已接受值；显式 undefined 正确识别。
- defaultValue/defaultOpen/defaultFileList/defaultSelectedRowKeys 仅初始化。
- Upload beforeUpload await 后基于最新 controlled fileList rebase，迟到上传回调不复活已删除项。
- 内部 helper 不从根入口导出；ES/CJS 声明与 JS 成对。

## 本地候选证据

候选：0c6cff6f3022ae7eeec5249f0a73096f3dd7c7b7

- components：63 files / 995 tests
- DnD：44 tests；AI：63 tests；治理脚本：85 tests
- typecheck、双构建 determinism、docs build、三包 tarball：通过
- Desktop WebKit R1：8/8
- QG4 desktop：14 passed / 3 skipped，截图无差异
- 开发经理、测试经理、设计审核：放行到 PR

## 发布检查

- [x] 已说明影响的产品任务及验收目标
- [x] source/es/lib 与内部构建入口已同步
- [x] 本地 P1/P2 实现问题清零
- [ ] GitHub PR CI 全绿
- [ ] 产品经理最终放行
