### PR TITLE
D2: unify overlay focus and dismissal

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -14,6 +14,10 @@ const loadingOpen = ref(false)
 const styledOpen = ref(false)
 const asyncOpen = ref(false)
 const guardedOpen = ref(false)
+const overlayContractOpen = ref(false)
+const nestedPopoverOpen = ref(false)
+const nestedDrawerOpen = ref(false)
+const modalAboveDrawerOpen = ref(false)
 const pending = ref(false)
 const requestError = ref('')
 const resolveRequest = ref<(() => void) | null>(null)
@@ -165,6 +169,45 @@ Modal focuses attention in a blocking dialog for decisions, confirmations, and s
 .modal-interaction-workbench__error p { margin: 0; }
 .modal-interaction-workbench__result { margin: 0; padding: 12px 24px; border-top: 1px solid #eef1f5; color: #667085; font-size: 13px; }
 @media (max-width: 640px) { .modal-interaction-workbench__toolbar { display: block; padding: 16px; } .modal-interaction-workbench__actions { justify-content: flex-start; margin-top: 16px; } .modal-interaction-workbench__result { padding: 12px 16px; } }
+</style>
+
+## D2 浮层焦点工作台
+
+<section class="d2-overlay-workbench" role="region" aria-label="浮层焦点工作台">
+  <p>这条路径把 Teleport 浮层、Modal 与 Drawer 放进同一层级：Escape 每次只关闭最上层，最后一层离场后才恢复页面滚动。</p>
+  <AButton type="primary" @click="overlayContractOpen = true">Open overlay contract</AButton>
+  <AModal v-model:open="overlayContractOpen" title="Overlay contract modal" :footer="false">
+    <p>先验证弹出内容，再验证混合阻塞层。</p>
+    <div class="d2-overlay-workbench__actions">
+      <APopover
+        v-model:open="nestedPopoverOpen"
+        title="Nested popover"
+        trigger="click"
+        placement="bottomLeft"
+      >
+        <AButton>Open nested popover</AButton>
+        <template #content>
+          <button type="button" class="d2-overlay-workbench__popup-action">Popover action</button>
+        </template>
+      </APopover>
+      <AButton @click="nestedDrawerOpen = true">Open nested drawer</AButton>
+    </div>
+    <ADrawer v-model:open="nestedDrawerOpen" title="Nested drawer" :width="360">
+      <p>Drawer 与外层 Modal 共用顶层关闭和焦点所有权。</p>
+      <AButton @click="modalAboveDrawerOpen = true">Open modal above drawer</AButton>
+      <AModal v-model:open="modalAboveDrawerOpen" title="Modal above drawer" :footer="false">
+        <p>Escape 只关闭这个 Modal，Drawer 仍保持打开。</p>
+      </AModal>
+    </ADrawer>
+  </AModal>
+</section>
+
+<style>
+.d2-overlay-workbench { display: grid; gap: 12px; margin: 20px 0 28px; padding: 20px; border: 1px solid #d9e1ea; border-radius: 8px; background: #fff; color: #344054; }
+.d2-overlay-workbench > p { margin: 0; color: #667085; }
+.d2-overlay-workbench__actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.d2-overlay-workbench__popup-action { min-height: 36px; padding: 7px 11px; border: 1px solid #98a2b3; border-radius: 6px; background: #fff; color: #344054; cursor: pointer; }
+.d2-overlay-workbench__popup-action:focus-visible { border-color: #1677ff; outline: 2px solid rgba(22, 119, 255, .25); outline-offset: 2px; }
 </style>
 
 ## 基础用法

--- a/docs/superpowers/reviews/2026-09-06-d2-overlay-focus.md
+++ b/docs/superpowers/reviews/2026-09-06-d2-overlay-focus.md
@@ -1,0 +1,61 @@
+# D2 浮层栈、焦点与无障碍验收记录
+
+## 范围
+
+- 新增内部 document 级 overlay controller，统一 Modal、Drawer 与浮动弹层的顶层 Escape、outside pointer、视觉层级和 owner tree。
+- Modal/Drawer 增加引用计数 body scroll lock，并在 leave 动画结束前保持锁定。
+- Dropdown、Tooltip、Popover、Popconfirm 修复 hover 延迟与 click/contextmenu/focus 竞态；Tooltip/Popover/Popconfirm 补真实焦点触发器与 popup 的 ARIA 关系。
+- Cascader、TreeSelect 补稳定 `aria-controls`、`aria-activedescendant`、label/description 关联与键盘导航。
+
+不包含公开 API/类型导出、主要依赖、包边界、全局视觉 token、组件视觉重设计、虚拟化、DnD 包或 AI 包改造。实体 iOS Safari 仍是独立于 Playwright mobile WebKit 的证据门禁，本记录不把自动化等同于实体设备验收。
+
+## 开发实施
+
+- 共享栈按 Document 隔离，支持 Teleport 后代递归 owner 判断与 `composedPath`；Escape/outside pointer 每次只分发给绝对顶层，顶层 `keyboard=false` 会阻断下层。
+- Modal/Drawer 与浮动弹层从同一栈获得递增有效 z-index；显式 z-index 作为下限，不再出现键盘顶层与视觉顶层不一致。
+- Modal/Drawer 按实际容器 Document 注册、锁滚动和恢复焦点；Safari/WebKit pointer 打开不聚焦按钮时，使用最近 pointer opener，keyboard 输入会清除该候选。
+- scroll lock 保存并恢复原始 `overflow`/`padding-right`，多层引用计数归零且 leave 完成后才释放。
+- `useTriggerAria` 只向真实可聚焦 slot 后代同步关系，合并并在卸载时恢复原有 token 属性。
+- Cascader/TreeSelect 使用 Vue SSR 稳定 ID；活动项不可见、搜索过滤或弹层关闭时不保留悬空 active descendant。
+
+## 开发经理复审
+
+- [x] 新增 helper 不从公共入口导出，未改变公开 props/events/types、包边界或主要依赖。
+- [x] attached document 由集中监听处理；detached/custom host 仅走本地兜底，受控拒绝关闭仍只发出一次请求。
+- [x] mixed Modal/Drawer/Floating 的 owner document、z-index、Escape、focus restore 与 leave 生命周期一致。
+- [x] source 与 es/lib 生成产物配对，diff 无无关 `pnpm-workspace.yaml` 漂移。
+- [x] 开发经理复审与测试经理复审均确认 P1=0、P2=0。
+
+## 测试经理测试
+
+- [x] overlay controller、floating dismiss、trigger ARIA、Modal/Drawer、Dropdown/Tooltip/Popover/Popconfirm、Cascader/TreeSelect 专项通过。
+- [x] leave scroll lock、custom owner document、受控拒绝、pointer opener、递归 Teleport、z-index、hover timer、focusout、SSR stable ID 与自动卸载均有回归测试。
+- [x] 全量 unit（components 66 files / 1026 tests、DnD 44、AI 63、scripts 86）、typecheck、组件/docs build 与 D2 ESM/CommonJS 配对契约通过。
+- [x] D2 嵌套路径在 Desktop Chromium、Mobile Chromium、Firefox、Desktop WebKit、Mobile WebKit 通过（5/5）。
+- [x] 三包 tarball 通过（components 943 files、DnD 71、AI 111）。
+- [x] 构建确定性与完整 Desktop WebKit R1 通过（9/9）。
+- [x] QG4 desktop 通过（14 passed / 3 skipped），axe、hydration、键盘与既有截图基线无未解释回退。
+- [ ] GitHub PR CI 与 master CI 全绿。
+
+## 设计审核
+
+- [x] 1440×900 下 Modal、teleported Popover、Drawer、Drawer 上层 Modal 的遮罩、层级、定位与焦点环通过截图检查。
+- [x] 390×844 下 Modal/Popover 不越界，Drawer 保持窄屏安全宽度，上层 Modal 完整覆盖 Drawer。
+- [x] 设计审核发现并修复“行为顶层正确但 Drawer 视觉压住上层 Modal”的 z-index P1；复拍后通过。
+- [x] 未修改全局设计基础、组件 token、既有布局或文案体系。
+
+## 产品经理最终验收
+
+- [x] 一次 Escape 只关闭 Popover → 上层 Modal → Drawer → 外层 Modal 中的当前最上层。
+- [x] 每层关闭后焦点回到该层实际 opener；Safari/WebKit pointer 入口与 keyboard 入口均可观察。
+- [x] 多层打开期间页面保持不可滚动，最后一层完全离场后恢复原始页面样式。
+- [x] Cascader/TreeSelect 键盘活动项与触发器 ARIA 引用保持可见、稳定且 SSR 一致。
+- [x] 开发/测试复审后 P1/P2 为零。
+- [ ] PR 留存完成，合并 master 后远端 CI 绿色。
+
+## GitHub 留存
+
+- 分支：`codex/d2-overlay-focus`
+- PR：待创建
+- 合并提交：待完成
+- master CI：待完成

--- a/e2e/cross-browser-r1.spec.ts
+++ b/e2e/cross-browser-r1.spec.ts
@@ -176,6 +176,57 @@ test.describe('QG5 R1 production cross-browser smoke', () => {
     await expect(trigger).toBeFocused()
   })
 
+  test('nested overlays close topmost-first and keep scroll and focus ownership', async ({ page }, testInfo) => {
+    const errors = await collectProductionErrors(page)
+    ;(testInfo as typeof testInfo & { __qg5Errors?: string[] }).__qg5Errors = errors
+    await expectProductionRoute(page, 'modal')
+
+    const modalTrigger = page.getByRole('button', { name: 'Open overlay contract', exact: true })
+    await modalTrigger.click()
+    const outerModal = page.getByRole('dialog', { name: 'Overlay contract modal' })
+    await expect(outerModal).toBeVisible()
+    await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+
+    const popoverTrigger = outerModal.getByRole('button', { name: 'Open nested popover', exact: true })
+    await popoverTrigger.click()
+    const nestedPopover = page.locator('.aheart-popover__popup').filter({ hasText: 'Nested popover' })
+    await expect(nestedPopover).toBeVisible()
+    await nestedPopover.getByRole('button', { name: 'Popover action' }).focus()
+    await expect(nestedPopover).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(nestedPopover).toBeHidden()
+    await expect(outerModal).toBeVisible()
+    await expect(popoverTrigger).toBeFocused()
+
+    const drawerTrigger = outerModal.getByRole('button', { name: 'Open nested drawer', exact: true })
+    await drawerTrigger.click()
+    const drawer = page.getByRole('dialog', { name: 'Nested drawer' })
+    await expect(drawer).toBeVisible()
+
+    const topModalTrigger = drawer.getByRole('button', { name: 'Open modal above drawer', exact: true })
+    await topModalTrigger.click()
+    const topModal = page.getByRole('dialog', { name: 'Modal above drawer' })
+    await expect(topModal).toBeVisible()
+    const topModalZIndex = await page.locator('.aheart-modal').filter({ has: topModal }).evaluate((element) => Number(getComputedStyle(element).zIndex))
+    const drawerZIndex = await page.locator('.aheart-drawer').filter({ has: drawer }).evaluate((element) => Number(getComputedStyle(element).zIndex))
+    expect(topModalZIndex).toBeGreaterThan(drawerZIndex)
+    await page.keyboard.press('Escape')
+    await expect(topModal).toBeHidden()
+    await expect(drawer).toBeVisible()
+    await expect(topModalTrigger).toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(drawer).toBeHidden()
+    await expect(outerModal).toBeVisible()
+    await expect(drawerTrigger).toBeFocused()
+    expect(await page.evaluate(() => document.body.style.overflow)).toBe('hidden')
+
+    await page.keyboard.press('Escape')
+    await expect(outerModal).toBeHidden()
+    await expect(modalTrigger).toBeFocused()
+    await expect.poll(() => page.evaluate(() => document.body.style.overflow)).not.toBe('hidden')
+  })
+
   test('DnD sorts by keyboard and Splitter resizes by keyboard', async ({ page }, testInfo) => {
     const errors = await collectProductionErrors(page)
     ;(testInfo as typeof testInfo & { __qg5Errors?: string[] }).__qg5Errors = errors

--- a/packages/components/es/cascader/cascader.vue.js
+++ b/packages/components/es/cascader/cascader.vue.js
@@ -1,13 +1,14 @@
-import { defineComponent, ref, computed, watch, openBlock, createElementBlock, normalizeClass, createElementVNode, Fragment, renderList, toDisplayString, withModifiers, createVNode, createCommentVNode, createBlock, Teleport, unref, withDirectives, normalizeStyle, vModelText, vShow, nextTick } from "vue";
+import { defineComponent, ref, computed, watch, useAttrs, openBlock, createElementBlock, normalizeClass, createElementVNode, Fragment, renderList, toDisplayString, withModifiers, createVNode, createCommentVNode, createBlock, Teleport, unref, withDirectives, normalizeStyle, vModelText, vShow, nextTick } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
 import { useControllableState } from "../utils/use-controllable-state.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import "./style.css.js";
-const _hoisted_1 = ["tabindex", "aria-expanded", "aria-disabled"];
+const _hoisted_1 = ["tabindex", "aria-expanded", "aria-disabled", "aria-activedescendant", "aria-labelledby", "aria-describedby"];
 const _hoisted_2 = {
   key: 0,
   class: "aheart-cascader__value aheart-cascader__tags"
@@ -18,17 +19,18 @@ const _hoisted_5 = {
   key: 0,
   class: "aheart-cascader__tag aheart-cascader__tag--rest"
 };
-const _hoisted_6 = {
+const _hoisted_6 = ["aria-labelledby", "aria-describedby", "aria-label"];
+const _hoisted_7 = {
   key: 1,
   class: "aheart-cascader__search-results"
 };
-const _hoisted_7 = ["data-cascader-path", "disabled", "onClick"];
-const _hoisted_8 = {
+const _hoisted_8 = ["data-cascader-path", "disabled", "onClick"];
+const _hoisted_9 = {
   key: 0,
   class: "aheart-cascader__empty",
   role: "status"
 };
-const _hoisted_9 = ["data-cascader-value", "disabled", "aria-busy", "onClick"];
+const _hoisted_10 = ["data-cascader-value", "id", "data-cascader-column", "disabled", "aria-busy", "onClick", "onFocus"];
 const _sfc_main = /* @__PURE__ */ defineComponent({
   ...{ name: "ACascader" },
   __name: "cascader",
@@ -57,12 +59,15 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       ...option,
       children: option.children ? cloneOptions(option.children) : void 0
     }));
+    const instanceId = useStableId(void 0, "aheart-cascader").value;
+    const panelId = `aheart-cascader-panel-${instanceId}`;
     const rootRef = ref(null);
     const triggerRef = ref(null);
     const panelRef = ref(null);
     const columnsRef = ref(null);
     const searchText = ref("");
     const activePath = ref([]);
+    const focusedPath = ref([]);
     const loadingPaths = ref([]);
     const innerOptions = ref(cloneOptions(props.options));
     const isControlled = usePropPresence("modelValue", "model-value");
@@ -165,6 +170,25 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       const query = searchText.value.trim().toLowerCase();
       return collectLeaves(innerOptions.value).filter((result) => result.labels.join(" / ").toLowerCase().includes(query));
     });
+    const attrs = useAttrs();
+    const resolvedAriaLabelledby = computed(() => attrs["aria-labelledby"]);
+    const resolvedAriaDescribedby = computed(() => attrs["aria-describedby"]);
+    const optionId = (option, columnIndex) => {
+      var _a;
+      return `${instanceId}-option-${columnIndex}-${Math.max(0, ((_a = columns.value[columnIndex]) == null ? void 0 : _a.indexOf(option)) ?? 0)}`;
+    };
+    const activeDescendantId = computed(() => {
+      var _a, _b, _c;
+      if (!mergedOpen.value || searchText.value.trim())
+        return void 0;
+      const path = focusedPath.value;
+      if (!path.length)
+        return void 0;
+      const option = ((_b = (_a = findOption(path.slice(0, -1))) == null ? void 0 : _a.children) == null ? void 0 : _b.find((item) => item.value === path.at(-1))) ?? (path.length === 1 ? innerOptions.value.find((item) => item.value === path[0]) : void 0);
+      if (!option || !((_c = columns.value[path.length - 1]) == null ? void 0 : _c.includes(option)))
+        return void 0;
+      return optionId(option, path.length - 1);
+    });
     const isSelected = (columnIndex, option) => selectedPaths.value.some((path) => path[columnIndex] === option.value && path.length === columnIndex + 1);
     const isLoading = (columnIndex, option) => loadingPaths.value.some((path) => samePath(path, [...activePath.value.slice(0, columnIndex), option.value]));
     const requestOpen = (open) => {
@@ -236,6 +260,9 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         }
       }
     };
+    const handleOptionFocus = (option, columnIndex) => {
+      focusedPath.value = [...activePath.value.slice(0, columnIndex), option.value];
+    };
     const handleTriggerKeydown = (event) => {
       if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
         event.preventDefault();
@@ -254,13 +281,15 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       }
     };
     const handleOptionKeydown = (event) => {
-      var _a, _b;
+      var _a, _b, _c, _d, _e, _f;
       const current = event.currentTarget;
       const options = Array.from(((_a = current.parentElement) == null ? void 0 : _a.querySelectorAll(".aheart-cascader__option:not(:disabled)")) ?? []);
       const index = options.indexOf(current);
+      const columnIndex = Number(current.dataset.cascaderColumn);
+      const option = (_b = columns.value[columnIndex]) == null ? void 0 : _b.find((item) => String(item.value) === current.dataset.cascaderValue);
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
-        (_b = options[(index + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length]) == null ? void 0 : _b.focus();
+        (_c = options[(index + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length]) == null ? void 0 : _c.focus();
       } else if (event.key === "Escape") {
         event.preventDefault();
         requestOpen(false);
@@ -268,6 +297,19 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           var _a2;
           return (_a2 = triggerRef.value) == null ? void 0 : _a2.focus();
         });
+      } else if (event.key === "Home" || event.key === "End") {
+        event.preventDefault();
+        (_d = options[event.key === "Home" ? 0 : options.length - 1]) == null ? void 0 : _d.focus();
+      } else if (event.key === "ArrowRight" && option && isBranch(option)) {
+        event.preventDefault();
+        void handleOption(option, columnIndex).then(() => nextTick(() => {
+          var _a2, _b2;
+          return (_b2 = (_a2 = panelRef.value) == null ? void 0 : _a2.querySelector(`[data-cascader-column="${columnIndex + 1}"]:not(:disabled)`)) == null ? void 0 : _b2.focus();
+        }));
+      } else if (event.key === "ArrowLeft" && columnIndex > 0) {
+        event.preventDefault();
+        const parentValue = focusedPath.value[columnIndex - 1] ?? activePath.value[columnIndex - 1];
+        (_f = Array.from(((_e = panelRef.value) == null ? void 0 : _e.querySelectorAll(`[data-cascader-column="${columnIndex - 1}"]`)) ?? []).find((element) => element.dataset.cascaderValue === String(parentValue))) == null ? void 0 : _f.focus();
       }
     };
     const motion = useMotionPresence(mergedOpen, { destroyOnHidden: true, duration: 120 });
@@ -313,6 +355,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           tabindex: __props.disabled ? -1 : 0,
           "aria-expanded": mergedOpen.value ? "true" : "false",
           "aria-disabled": __props.disabled ? "true" : void 0,
+          "aria-controls": panelId,
+          "aria-activedescendant": activeDescendantId.value,
+          "aria-labelledby": resolvedAriaLabelledby.value,
+          "aria-describedby": resolvedAriaDescribedby.value,
           "aria-haspopup": "dialog",
           onClick: toggleOpen,
           onKeydown: handleTriggerKeydown
@@ -373,7 +419,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             class: normalizeClass(["aheart-cascader__panel", panelClass.value]),
             style: normalizeStyle(panelStyle.value),
             role: "dialog",
-            "aria-label": "级联选择"
+            id: panelId,
+            "aria-labelledby": resolvedAriaLabelledby.value || void 0,
+            "aria-describedby": resolvedAriaDescribedby.value || void 0,
+            "aria-label": resolvedAriaLabelledby.value ? void 0 : "级联选择"
           }, [
             __props.showSearch ? withDirectives((openBlock(), createElementBlock("input", {
               key: 0,
@@ -385,7 +434,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             }, null, 512)), [
               [vModelText, searchText.value]
             ]) : createCommentVNode("", true),
-            searchText.value.trim() ? (openBlock(), createElementBlock("div", _hoisted_6, [
+            searchText.value.trim() ? (openBlock(), createElementBlock("div", _hoisted_7, [
               (openBlock(true), createElementBlock(Fragment, null, renderList(searchResults.value, (result) => {
                 return openBlock(), createElementBlock("button", {
                   key: pathKey(result.path),
@@ -394,9 +443,9 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                   "data-cascader-path": pathKey(result.path),
                   disabled: __props.disabled || result.disabled,
                   onClick: ($event) => selectPath(result.path)
-                }, toDisplayString(result.labels.join(" / ")), 9, _hoisted_7);
+                }, toDisplayString(result.labels.join(" / ")), 9, _hoisted_8);
               }), 128)),
-              searchResults.value.length === 0 ? (openBlock(), createElementBlock("div", _hoisted_8, "暂无匹配选项")) : createCommentVNode("", true)
+              searchResults.value.length === 0 ? (openBlock(), createElementBlock("div", _hoisted_9, "暂无匹配选项")) : createCommentVNode("", true)
             ])) : (openBlock(), createElementBlock("div", {
               key: 2,
               ref_key: "columnsRef",
@@ -414,9 +463,12 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                       class: normalizeClass(["aheart-cascader__option", { "is-active": activePath.value[columnIndex] === option.value, "is-selected": isSelected(columnIndex, option), "is-loading": isLoading(columnIndex, option) }]),
                       type: "button",
                       "data-cascader-value": option.value,
+                      id: optionId(option, columnIndex),
+                      "data-cascader-column": columnIndex,
                       disabled: __props.disabled || option.disabled || isLoading(columnIndex, option),
                       "aria-busy": isLoading(columnIndex, option) ? "true" : void 0,
                       onClick: ($event) => handleOption(option, columnIndex),
+                      onFocus: ($event) => handleOptionFocus(option, columnIndex),
                       onKeydown: handleOptionKeydown
                     }, [
                       createElementVNode("span", null, toDisplayString(option.label), 1),
@@ -432,12 +484,12 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                         size: 16,
                         "aria-hidden": "true"
                       })) : createCommentVNode("", true)
-                    ], 42, _hoisted_9);
+                    ], 42, _hoisted_10);
                   }), 128))
                 ]);
               }), 128))
             ], 512))
-          ], 6)), [
+          ], 14, _hoisted_6)), [
             [vShow, unref(motion).phase.value !== "hidden"]
           ]) : createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/es/drawer/drawer.vue.js
+++ b/packages/components/es/drawer/drawer.vue.js
@@ -1,8 +1,9 @@
-import { defineComponent, useSlots, getCurrentInstance, computed, ref, inject, provide, watch, nextTick, onBeforeUnmount, onMounted, openBlock, createBlock, Teleport, unref, withDirectives, createElementBlock, normalizeClass, normalizeStyle, createCommentVNode, createVNode, withCtx, createElementVNode, renderSlot, vShow } from "vue";
+import { defineComponent, useSlots, getCurrentInstance, computed, ref, inject, provide, watch, nextTick, onBeforeMount, onBeforeUnmount, onMounted, openBlock, createBlock, Teleport, unref, withDirectives, createElementBlock, normalizeClass, normalizeStyle, createCommentVNode, createVNode, withCtx, createElementVNode, renderSlot, vShow } from "vue";
 import Skeleton from "../skeleton/index.js";
 import { usePointerDrag } from "../utils/use-pointer-drag.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
+import { getRecentPointerTarget, prepareOverlayDocument, isTopmost, registerOverlay, lockBodyScroll, refreshOverlayStack, unregisterOverlay, unlockBodyScroll } from "../utils/overlay-controller.js";
 import { drawerProps, drawerEmits } from "./types.js";
 import "./style.css.js";
 const _hoisted_1 = ["aria-hidden"];
@@ -66,10 +67,48 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const leaveFocusElement = ref(null);
     const titleId = `aheart-drawer-title-${(instance == null ? void 0 : instance.uid) ?? "dialog"}`;
     let pendingCloseCompletion = false;
+    let overlayRegistered = false;
+    const drawerId = Symbol("ADrawer");
+    let overlayDocument = null;
+    const effectiveZIndex = ref(props.zIndex);
     const resizedSize = ref();
     const resizeStart = ref(null);
+    const getDrawerDocument = () => {
+      var _a, _b;
+      const target = teleportTarget.value;
+      return ((_a = panelRef.value) == null ? void 0 : _a.ownerDocument) ?? ((_b = triggerElement.value) == null ? void 0 : _b.ownerDocument) ?? (typeof target === "object" && target ? target.ownerDocument : document);
+    };
+    const isDrawerTopmost = () => isTopmost(drawerId, overlayDocument ?? getDrawerDocument());
+    const registerDrawerOverlay = () => {
+      if (overlayRegistered)
+        return;
+      const ownerDocument = getDrawerDocument();
+      registerOverlay({
+        id: drawerId,
+        document: ownerDocument,
+        getTrigger: () => triggerElement.value,
+        getContent: () => panelRef.value,
+        escapeEnabled: () => props.open && props.keyboard,
+        getBaseZIndex: () => props.zIndex,
+        onZIndexChange: (zIndex) => {
+          effectiveZIndex.value = zIndex;
+        },
+        onEscape: close
+      });
+      lockBodyScroll(ownerDocument);
+      overlayDocument = ownerDocument;
+      overlayRegistered = true;
+    };
+    const unregisterDrawerOverlay = () => {
+      if (!overlayRegistered)
+        return;
+      const ownerDocument = overlayDocument ?? getDrawerDocument();
+      unregisterOverlay(drawerId, ownerDocument);
+      unlockBodyScroll(ownerDocument);
+      overlayDocument = null;
+      overlayRegistered = false;
+    };
     const parentPushContext = inject(DRAWER_PUSH_CONTEXT, null);
-    const drawerId = Symbol("ADrawer");
     const openChildDrawers = ref(/* @__PURE__ */ new Map());
     const setChildOpen = (id, open) => {
       const nextOpenChildren = new Map(openChildDrawers.value);
@@ -241,7 +280,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const rootStyle = computed(() => ({
       ...props.rootStyle,
       ...semanticStyle("root"),
-      zIndex: props.zIndex
+      zIndex: effectiveZIndex.value
     }));
     const mergedMaskStyle = computed(() => ({
       ...props.maskStyle,
@@ -295,20 +334,23 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     watch(
       () => props.open,
       (open, previousOpen) => {
-        var _a;
+        var _a, _b;
         if (open && !previousOpen) {
           pendingCloseCompletion = false;
           leaveFocusElement.value = null;
           if (motion.phase.value === "hidden")
             captureTriggerElement();
+          registerDrawerOverlay();
           emit("afterOpenChange", true);
         }
         if (!open) {
           pendingCloseCompletion = true;
-          const activeElement = document.activeElement;
-          leaveFocusElement.value = activeElement instanceof HTMLElement && ((_a = panelRef.value) == null ? void 0 : _a.contains(activeElement)) ? activeElement : null;
+          const ownerDocument = overlayDocument ?? getDrawerDocument();
+          const activeElement = ownerDocument.activeElement;
+          const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+          leaveFocusElement.value = HTMLElementConstructor && activeElement instanceof HTMLElementConstructor && ((_b = panelRef.value) == null ? void 0 : _b.contains(activeElement)) ? activeElement : null;
           void nextTick(() => {
-            if (motion.phase.value === "leave" && leaveFocusElement.value && document.contains(leaveFocusElement.value)) {
+            if (motion.phase.value === "leave" && leaveFocusElement.value && ownerDocument.contains(leaveFocusElement.value)) {
               leaveFocusElement.value.focus();
             }
           });
@@ -317,13 +359,24 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       { flush: "sync" }
     );
     watch(
+      () => props.zIndex,
+      (zIndex) => {
+        if (overlayRegistered)
+          refreshOverlayStack(overlayDocument ?? getDrawerDocument());
+        else
+          effectiveZIndex.value = zIndex;
+      }
+    );
+    watch(
       () => motion.phase.value,
       (phase) => {
         if (phase === "entered" && props.open) {
-          void nextTick(() => focusPanel());
+          if (isDrawerTopmost())
+            void nextTick(() => focusPanel());
           return;
         }
         if (phase === "hidden" && !props.open && pendingCloseCompletion) {
+          unregisterDrawerOverlay();
           pendingCloseCompletion = false;
           emit("afterOpenChange", false);
           void nextTick(() => restoreTriggerFocus());
@@ -338,7 +391,12 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       },
       { immediate: true }
     );
+    onBeforeMount(() => {
+      if (props.open)
+        registerDrawerOverlay();
+    });
     onBeforeUnmount(() => {
+      unregisterDrawerOverlay();
       parentPushContext == null ? void 0 : parentPushContext.setChildOpen(drawerId, false);
     });
     const resolveSemanticConfig = (config, part) => {
@@ -348,16 +406,20 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const semanticClass = (part) => resolveSemanticConfig(props.classNames, part);
     const semanticStyle = (part) => resolveSemanticConfig(props.styles, part);
     const captureTriggerElement = () => {
-      triggerElement.value = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      var _a;
+      const ownerDocument = getDrawerDocument();
+      const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+      const pointerTarget = getRecentPointerTarget(ownerDocument);
+      triggerElement.value = HTMLElementConstructor && pointerTarget instanceof HTMLElementConstructor ? pointerTarget : HTMLElementConstructor && ownerDocument.activeElement instanceof HTMLElementConstructor ? ownerDocument.activeElement : null;
     };
     const restoreTriggerFocus = () => {
       const target = triggerElement.value;
-      if (!shouldFocusTriggerAfterClose.value || !target || !document.contains(target)) {
+      if (!shouldFocusTriggerAfterClose.value || !target || !target.ownerDocument.contains(target)) {
         return;
       }
       target.focus();
     };
-    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element instanceof HTMLInputElement && element.type === "hidden");
+    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element.tagName === "INPUT" && element.type === "hidden");
     const getFocusableElements = () => {
       const panel = panelRef.value;
       if (!panel) {
@@ -366,7 +428,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       return Array.from(panel.querySelectorAll(FOCUSABLE_SELECTOR)).filter(isFocusableElementAvailable);
     };
     const focusPanel = () => {
-      if (!props.open) {
+      if (!props.open || !isDrawerTopmost()) {
         return;
       }
       const panel = panelRef.value;
@@ -374,6 +436,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       target == null ? void 0 : target.focus();
     };
     onMounted(() => {
+      prepareOverlayDocument(getDrawerDocument());
       if (!props.open) {
         return;
       }
@@ -381,7 +444,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       focusPanel();
     });
     const handleTrapTab = (event) => {
-      if (!props.open || !shouldTrapFocus.value || event.key !== "Tab") {
+      if (!props.open || !isDrawerTopmost() || !shouldTrapFocus.value || event.key !== "Tab") {
         return;
       }
       const panel = panelRef.value;
@@ -391,7 +454,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       const focusableElements = getFocusableElements();
       const firstElement = focusableElements[0] ?? panel;
       const lastElement = focusableElements[focusableElements.length - 1] ?? panel;
-      const activeElement = document.activeElement;
+      const activeElement = panel.ownerDocument.activeElement;
       if (event.shiftKey) {
         if (activeElement === firstElement || !panel.contains(activeElement)) {
           event.preventDefault();
@@ -483,7 +546,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     const handleKeydown = (event) => {
       handleTrapTab(event);
-      if (props.keyboard && event.key === "Escape") {
+      const ownerDocument = overlayDocument ?? getDrawerDocument();
+      if (!event.composedPath().includes(ownerDocument) && props.open && props.keyboard && event.key === "Escape" && isDrawerTopmost()) {
+        event.preventDefault();
+        event.stopPropagation();
         close();
       }
     };

--- a/packages/components/es/dropdown/dropdown.vue.js
+++ b/packages/components/es/dropdown/dropdown.vue.js
@@ -221,6 +221,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       if (!triggerSet.value.has("click")) {
         return;
       }
+      clearHoverTimers();
       setOpen(!mergedOpen.value, { source: "trigger" });
     };
     const handleMouseEnter = () => {
@@ -239,6 +240,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     const handleContextmenu = (event) => {
       if (triggerSet.value.has("contextMenu")) {
+        clearHoverTimers();
         event.preventDefault();
         setOpen(true, { source: "trigger" });
       }

--- a/packages/components/es/modal/modal.vue.js
+++ b/packages/components/es/modal/modal.vue.js
@@ -4,24 +4,12 @@ import Skeleton from "../skeleton/index.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import { modalProps, modalEmits } from "./types.js";
+import { getRecentPointerTarget, prepareOverlayDocument, isTopmost, registerOverlay, lockBodyScroll, refreshOverlayStack, unregisterOverlay, unlockBodyScroll } from "../utils/overlay-controller.js";
 import "./style.css.js";
 import { useAheartConfig } from "../config/context.js";
 const _hoisted_1 = ["aria-hidden"];
 const _hoisted_2 = ["aria-label", "aria-labelledby"];
 const _hoisted_3 = ["disabled", "aria-label"];
-const openModalStack = [];
-const registerOpenModal = (id) => {
-  const previousIndex = openModalStack.indexOf(id);
-  if (previousIndex >= 0)
-    openModalStack.splice(previousIndex, 1);
-  openModalStack.push(id);
-};
-const unregisterOpenModal = (id) => {
-  const index = openModalStack.indexOf(id);
-  if (index >= 0)
-    openModalStack.splice(index, 1);
-};
-const isTopmostOpenModal = (id) => openModalStack[openModalStack.length - 1] === id;
 const _sfc_main = /* @__PURE__ */ defineComponent({
   ...{
     name: "AModal"
@@ -55,6 +43,44 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const modalStackId = Symbol("aheart-modal");
     const titleId = `aheart-modal-title-${(instance == null ? void 0 : instance.uid) ?? "dialog"}`;
     let pendingCloseCompletion = false;
+    let overlayRegistered = false;
+    let overlayDocument = null;
+    const effectiveZIndex = ref(props.zIndex);
+    const getModalDocument = () => {
+      var _a, _b;
+      const target = teleportTarget.value;
+      return ((_a = dialogRef.value) == null ? void 0 : _a.ownerDocument) ?? ((_b = triggerElement.value) == null ? void 0 : _b.ownerDocument) ?? (typeof target === "object" && target ? target.ownerDocument : document);
+    };
+    const isModalTopmost = () => isTopmost(modalStackId, overlayDocument ?? getModalDocument());
+    const registerModalOverlay = () => {
+      if (overlayRegistered)
+        return;
+      const ownerDocument = getModalDocument();
+      registerOverlay({
+        id: modalStackId,
+        document: ownerDocument,
+        getTrigger: () => triggerElement.value,
+        getContent: () => dialogRef.value,
+        escapeEnabled: () => props.open && props.keyboard,
+        getBaseZIndex: () => props.zIndex,
+        onZIndexChange: (zIndex) => {
+          effectiveZIndex.value = zIndex;
+        },
+        onEscape: close
+      });
+      lockBodyScroll(ownerDocument);
+      overlayDocument = ownerDocument;
+      overlayRegistered = true;
+    };
+    const unregisterModalOverlay = () => {
+      if (!overlayRegistered)
+        return;
+      const ownerDocument = overlayDocument ?? getModalDocument();
+      unregisterOverlay(modalStackId, ownerDocument);
+      unlockBodyScroll(ownerDocument);
+      overlayDocument = null;
+      overlayRegistered = false;
+    };
     const AModalRenderNode = defineComponent({
       name: "AModalRenderNode",
       props: {
@@ -136,7 +162,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const rootStyle = computed(() => ({
       ...props.rootStyle,
       ...semanticStyle("root"),
-      zIndex: props.zIndex
+      zIndex: effectiveZIndex.value
     }));
     const hasTitle = computed(() => Boolean(slots.title) || hasRenderable(props.title));
     const hasHeader = computed(() => hasTitle.value || showCloseButton.value);
@@ -275,22 +301,23 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     watch(
       () => props.open,
       (open, previousOpen) => {
-        var _a;
+        var _a, _b;
         if (open && !previousOpen) {
-          registerOpenModal(modalStackId);
           pendingCloseCompletion = false;
           leaveFocusElement.value = null;
           if (motion.phase.value === "hidden")
             captureTriggerElement();
+          registerModalOverlay();
           emit("afterOpenChange", true);
         }
         if (!open) {
-          unregisterOpenModal(modalStackId);
           pendingCloseCompletion = true;
-          const activeElement = document.activeElement;
-          leaveFocusElement.value = activeElement instanceof HTMLElement && ((_a = dialogRef.value) == null ? void 0 : _a.contains(activeElement)) ? activeElement : null;
+          const ownerDocument = overlayDocument ?? getModalDocument();
+          const activeElement = ownerDocument.activeElement;
+          const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+          leaveFocusElement.value = HTMLElementConstructor && activeElement instanceof HTMLElementConstructor && ((_b = dialogRef.value) == null ? void 0 : _b.contains(activeElement)) ? activeElement : null;
           void nextTick(() => {
-            if (motion.phase.value === "leave" && leaveFocusElement.value && document.contains(leaveFocusElement.value)) {
+            if (motion.phase.value === "leave" && leaveFocusElement.value && ownerDocument.contains(leaveFocusElement.value)) {
               leaveFocusElement.value.focus();
             }
           });
@@ -299,9 +326,18 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       { flush: "sync" }
     );
     watch(
+      () => props.zIndex,
+      (zIndex) => {
+        if (overlayRegistered)
+          refreshOverlayStack(overlayDocument ?? getModalDocument());
+        else
+          effectiveZIndex.value = zIndex;
+      }
+    );
+    watch(
       () => props.open,
       (open) => {
-        if (open && isTopmostOpenModal(modalStackId))
+        if (open && isModalTopmost())
           focusDialog();
       },
       { flush: "post" }
@@ -310,11 +346,12 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       () => motion.phase.value,
       (phase) => {
         var _a, _b;
-        if (phase === "entered" && props.open && isTopmostOpenModal(modalStackId)) {
+        if (phase === "entered" && props.open && isModalTopmost()) {
           void nextTick(() => focusDialog());
           return;
         }
         if (phase === "hidden" && !props.open && pendingCloseCompletion) {
+          unregisterModalOverlay();
           pendingCloseCompletion = false;
           emit("afterOpenChange", false);
           emit("afterClose");
@@ -342,16 +379,20 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       return Object.keys(merged).length > 0 ? merged : void 0;
     };
     const captureTriggerElement = () => {
-      triggerElement.value = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      var _a;
+      const ownerDocument = getModalDocument();
+      const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+      const pointerTarget = getRecentPointerTarget(ownerDocument);
+      triggerElement.value = HTMLElementConstructor && pointerTarget instanceof HTMLElementConstructor ? pointerTarget : HTMLElementConstructor && ownerDocument.activeElement instanceof HTMLElementConstructor ? ownerDocument.activeElement : null;
     };
     const restoreTriggerFocus = () => {
       const target = triggerElement.value;
-      if (!shouldFocusTriggerAfterClose.value || !target || !document.contains(target)) {
+      if (!shouldFocusTriggerAfterClose.value || !target || !target.ownerDocument.contains(target)) {
         return;
       }
       target.focus();
     };
-    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element instanceof HTMLInputElement && element.type === "hidden");
+    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element.tagName === "INPUT" && element.type === "hidden");
     const getFocusableElements = () => {
       const dialog = dialogRef.value;
       if (!dialog) {
@@ -369,22 +410,21 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     onBeforeMount(() => {
       if (props.open)
-        registerOpenModal(modalStackId);
+        registerModalOverlay();
     });
     onMounted(() => {
-      document.addEventListener("keydown", handleEnteringKeydown);
-      if (!props.open || !isTopmostOpenModal(modalStackId)) {
+      prepareOverlayDocument(getModalDocument());
+      if (!props.open || !isModalTopmost()) {
         return;
       }
       captureTriggerElement();
       focusDialog();
     });
     onBeforeUnmount(() => {
-      document.removeEventListener("keydown", handleEnteringKeydown);
-      unregisterOpenModal(modalStackId);
+      unregisterModalOverlay();
     });
     const handleTrapTab = (event) => {
-      if (!props.open || !shouldTrapFocus.value || event.key !== "Tab") {
+      if (!props.open || !isModalTopmost() || !shouldTrapFocus.value || event.key !== "Tab") {
         return;
       }
       const dialog = dialogRef.value;
@@ -394,7 +434,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       const focusableElements = getFocusableElements();
       const firstElement = focusableElements[0] ?? dialog;
       const lastElement = focusableElements[focusableElements.length - 1] ?? dialog;
-      const activeElement = document.activeElement;
+      const activeElement = dialog.ownerDocument.activeElement;
       if (event.shiftKey) {
         if (activeElement === firstElement || !dialog.contains(activeElement)) {
           event.preventDefault();
@@ -434,17 +474,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         close();
       }
     };
-    const handleEnteringKeydown = (event) => {
-      if (!props.open || !props.keyboard || event.key !== "Escape" || motion.phase.value !== "enter" || document.activeElement !== triggerElement.value || !isTopmostOpenModal(modalStackId)) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      close();
-    };
     const handleKeydown = (event) => {
       handleTrapTab(event);
-      if (props.keyboard && event.key === "Escape" && isTopmostOpenModal(modalStackId)) {
+      const ownerDocument = overlayDocument ?? getModalDocument();
+      if (!event.composedPath().includes(ownerDocument) && props.open && props.keyboard && event.key === "Escape" && isModalTopmost()) {
         event.preventDefault();
         event.stopPropagation();
         close();

--- a/packages/components/es/popconfirm/popconfirm.vue.js
+++ b/packages/components/es/popconfirm/popconfirm.vue.js
@@ -1,4 +1,4 @@
-import { defineComponent, useSlots, ref, computed, watch, onBeforeUnmount, openBlock, createElementBlock, normalizeClass, normalizeStyle, createElementVNode, renderSlot, createBlock, Teleport, withDirectives, unref, createCommentVNode, createVNode, mergeProps, withCtx, createTextVNode, toDisplayString, vShow } from "vue";
+import { defineComponent, useSlots, ref, computed, watch, onBeforeUnmount, openBlock, createElementBlock, normalizeClass, normalizeStyle, createElementVNode, unref, renderSlot, createBlock, Teleport, withDirectives, createCommentVNode, createVNode, mergeProps, withCtx, createTextVNode, toDisplayString, vShow } from "vue";
 import Button from "../button/index.js";
 import { normalizeFloatingTriggers, getFloatingPopupStyle } from "../utils/floating-core.js";
 import "../utils/floating.css.js";
@@ -6,9 +6,13 @@ import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
+import { useStableId } from "../utils/use-stable-id.js";
+import { useTriggerAria } from "../utils/use-trigger-aria.js";
 import { popconfirmProps, popconfirmEmits } from "./types.js";
 import "./style.css.js";
-const _hoisted_1 = ["aria-hidden"];
+const _hoisted_1 = ["aria-controls", "aria-expanded"];
+const _hoisted_2 = ["id", "aria-labelledby", "aria-hidden"];
+const _hoisted_3 = ["id"];
 const _sfc_main = /* @__PURE__ */ defineComponent({
   ...{
     name: "APopconfirm"
@@ -37,6 +41,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const rootRef = ref(null);
     const triggerRef = ref(null);
     const popupRef = ref(null);
+    const popupId = useStableId(void 0, "aheart-popconfirm");
+    const titleId = useStableId(void 0, "aheart-popconfirm-title");
     const arrowRef = ref(null);
     const effectivePlacement = ref(props.placement);
     const isControlled = computed(() => props.open !== void 0);
@@ -73,6 +79,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const resolvedIcon = computed(() => props.icon === void 0 ? "!" : props.icon);
     const hasIcon = computed(() => Boolean(slots.icon) || hasRenderable(resolvedIcon.value));
     const hasTitle = computed(() => Boolean(slots.title) || hasRenderable(props.title));
+    useTriggerAria(triggerRef, () => ({
+      "aria-controls": popupId.value,
+      "aria-expanded": mergedOpen.value ? "true" : "false"
+    }));
     const hasDescription = computed(() => Boolean(slots.description) || hasRenderable(props.description));
     const semanticInfo = computed(() => ({
       open: visible.value,
@@ -237,21 +247,30 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     const handleFocusIn = () => {
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
         requestOpen(true);
       }
     };
-    const handleFocusOut = () => {
+    const handleFocusOut = (event) => {
+      var _a, _b;
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && (((_a = rootRef.value) == null ? void 0 : _a.contains(nextTarget)) || ((_b = popupRef.value) == null ? void 0 : _b.contains(nextTarget)))) {
+          return;
+        }
         requestOpen(false);
       }
     };
     const handleClick = () => {
       if (normalizedTriggers.value.has("click")) {
+        clearHoverTimers();
         requestOpen(!mergedOpen.value);
       }
     };
     const handleContextmenu = (event) => {
       if (normalizedTriggers.value.has("contextMenu")) {
+        clearHoverTimers();
         event.preventDefault();
         requestOpen(true);
       }
@@ -289,6 +308,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           ref_key: "triggerRef",
           ref: triggerRef,
           class: normalizeClass(["aheart-popconfirm__trigger", triggerClass.value]),
+          "aria-controls": unref(popupId),
+          "aria-expanded": mergedOpen.value ? "true" : "false",
           style: normalizeStyle(triggerStyle.value),
           onMouseenter: handleMouseEnter,
           onMouseleave: handleMouseLeave,
@@ -298,7 +319,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           onContextmenu: handleContextmenu
         }, [
           renderSlot(_ctx.$slots, "default")
-        ], 38),
+        ], 46, _hoisted_1),
         (openBlock(), createBlock(Teleport, {
           to: teleportTo.value,
           disabled: !shouldTeleport.value
@@ -308,11 +329,14 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             ref_key: "popupRef",
             ref: popupRef,
             class: normalizeClass(["aheart-popconfirm__popup", popupClass.value]),
+            id: unref(popupId),
             style: normalizeStyle(popupStyle.value),
             role: "dialog",
+            "aria-labelledby": hasTitle.value ? unref(titleId) : void 0,
             "aria-hidden": unref(motion).phase.value === "hidden" ? "true" : void 0,
             onMouseenter: handleMouseEnter,
             onMouseleave: handleMouseLeave,
+            onFocusout: handleFocusOut,
             onClick: handlePopupClick
           }, [
             showArrow.value ? (openBlock(), createElementBlock("span", {
@@ -347,13 +371,14 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                 }, [
                   hasTitle.value ? (openBlock(), createElementBlock("span", {
                     key: 0,
+                    id: unref(titleId),
                     class: normalizeClass(["aheart-popconfirm__title", titleClass.value]),
                     style: normalizeStyle(titleStyle.value)
                   }, [
                     renderSlot(_ctx.$slots, "title", {}, () => [
                       createVNode(unref(ARenderNode), { node: _ctx.title }, null, 8, ["node"])
                     ])
-                  ], 6)) : createCommentVNode("", true),
+                  ], 14, _hoisted_3)) : createCommentVNode("", true),
                   hasDescription.value ? (openBlock(), createElementBlock("span", {
                     key: 1,
                     class: normalizeClass(["aheart-popconfirm__description", descriptionClass.value]),
@@ -391,7 +416,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                 }, 16, ["class", "style"])
               ], 6)
             ], 6)
-          ], 46, _hoisted_1)), [
+          ], 46, _hoisted_2)), [
             [vShow, unref(motion).phase.value !== "hidden"]
           ]) : createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/es/popover/popover.vue.js
+++ b/packages/components/es/popover/popover.vue.js
@@ -1,13 +1,17 @@
-import { defineComponent, useSlots, ref, computed, watch, onBeforeUnmount, openBlock, createElementBlock, normalizeClass, normalizeStyle, createElementVNode, renderSlot, createBlock, Teleport, withDirectives, unref, createCommentVNode, createVNode, vShow } from "vue";
+import { defineComponent, useSlots, ref, computed, watch, onBeforeUnmount, openBlock, createElementBlock, normalizeClass, normalizeStyle, createElementVNode, unref, renderSlot, createBlock, Teleport, withDirectives, createCommentVNode, createVNode, vShow } from "vue";
 import { normalizeFloatingTriggers, getFloatingPopupStyle } from "../utils/floating-core.js";
 import "../utils/floating.css.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
+import { useStableId } from "../utils/use-stable-id.js";
+import { useTriggerAria } from "../utils/use-trigger-aria.js";
 import { popoverProps, popoverEmits } from "./types.js";
 import "./style.css.js";
-const _hoisted_1 = ["aria-hidden"];
+const _hoisted_1 = ["aria-controls", "aria-expanded"];
+const _hoisted_2 = ["id", "aria-labelledby", "aria-hidden"];
+const _hoisted_3 = ["id"];
 const _sfc_main = /* @__PURE__ */ defineComponent({
   ...{
     name: "APopover"
@@ -36,6 +40,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const rootRef = ref(null);
     const triggerRef = ref(null);
     const popupRef = ref(null);
+    const popupId = useStableId(void 0, "aheart-popover");
+    const titleId = useStableId(void 0, "aheart-popover-title");
     const arrowRef = ref(null);
     const effectivePlacement = ref(props.placement);
     let mouseEnterTimer;
@@ -44,6 +50,10 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const mergedOpen = computed(() => props.open ?? innerOpen.value);
     const normalizedTriggers = computed(() => new Set(normalizeFloatingTriggers(props.trigger)));
     const hasTitle = computed(() => Boolean(slots.title) || hasRenderable(props.title));
+    useTriggerAria(triggerRef, () => ({
+      "aria-controls": popupId.value,
+      "aria-expanded": mergedOpen.value ? "true" : "false"
+    }));
     const hasContent = computed(() => Boolean(slots.content) || hasRenderable(props.content));
     const hasPopupContent = computed(() => hasTitle.value || hasContent.value);
     const visible = computed(() => hasPopupContent.value && mergedOpen.value);
@@ -202,21 +212,30 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     const handleFocusIn = () => {
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
         requestOpen(true);
       }
     };
-    const handleFocusOut = () => {
+    const handleFocusOut = (event) => {
+      var _a, _b;
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && (((_a = rootRef.value) == null ? void 0 : _a.contains(nextTarget)) || ((_b = popupRef.value) == null ? void 0 : _b.contains(nextTarget)))) {
+          return;
+        }
         requestOpen(false);
       }
     };
     const handleClick = () => {
       if (normalizedTriggers.value.has("click")) {
+        clearHoverTimers();
         requestOpen(!mergedOpen.value);
       }
     };
     const handleContextmenu = (event) => {
       if (normalizedTriggers.value.has("contextMenu")) {
+        clearHoverTimers();
         event.preventDefault();
         requestOpen(true);
       }
@@ -243,6 +262,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           ref_key: "triggerRef",
           ref: triggerRef,
           class: normalizeClass(["aheart-popover__trigger", triggerClass.value]),
+          "aria-controls": unref(popupId),
+          "aria-expanded": mergedOpen.value ? "true" : "false",
           style: normalizeStyle(triggerStyle.value),
           onMouseenter: handleMouseEnter,
           onMouseleave: handleMouseLeave,
@@ -252,7 +273,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           onContextmenu: handleContextmenu
         }, [
           renderSlot(_ctx.$slots, "default")
-        ], 38),
+        ], 46, _hoisted_1),
         (openBlock(), createBlock(Teleport, {
           to: teleportTo.value,
           disabled: !shouldTeleport.value
@@ -262,11 +283,14 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             ref_key: "popupRef",
             ref: popupRef,
             class: normalizeClass(["aheart-popover__popup", popupClass.value]),
+            id: unref(popupId),
             style: normalizeStyle(popupStyle.value),
             role: "dialog",
+            "aria-labelledby": hasTitle.value ? unref(titleId) : void 0,
             "aria-hidden": unref(motion).phase.value === "hidden" ? "true" : void 0,
             onMouseenter: handleMouseEnter,
-            onMouseleave: handleMouseLeave
+            onMouseleave: handleMouseLeave,
+            onFocusout: handleFocusOut
           }, [
             showArrow.value ? (openBlock(), createElementBlock("span", {
               key: 0,
@@ -282,13 +306,14 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             }, [
               hasTitle.value ? (openBlock(), createElementBlock("span", {
                 key: 0,
+                id: unref(titleId),
                 class: normalizeClass(["aheart-popover__title", titleClass.value]),
                 style: normalizeStyle(titleStyle.value)
               }, [
                 renderSlot(_ctx.$slots, "title", {}, () => [
                   createVNode(unref(ARenderNode), { node: _ctx.title }, null, 8, ["node"])
                 ])
-              ], 6)) : createCommentVNode("", true),
+              ], 14, _hoisted_3)) : createCommentVNode("", true),
               hasContent.value ? (openBlock(), createElementBlock("span", {
                 key: 1,
                 class: normalizeClass(["aheart-popover__content", contentClass.value]),
@@ -299,7 +324,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                 ])
               ], 6)) : createCommentVNode("", true)
             ], 6)
-          ], 46, _hoisted_1)), [
+          ], 46, _hoisted_2)), [
             [vShow, unref(motion).phase.value !== "hidden"]
           ]) : createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/es/tooltip/tooltip.vue.js
+++ b/packages/components/es/tooltip/tooltip.vue.js
@@ -1,13 +1,16 @@
-import { defineComponent, useSlots, ref, computed, watch, onBeforeUnmount, openBlock, createElementBlock, normalizeClass, normalizeStyle, createElementVNode, renderSlot, createBlock, Teleport, withDirectives, unref, createCommentVNode, createVNode, vShow } from "vue";
+import { defineComponent, useSlots, ref, computed, watch, onBeforeUnmount, openBlock, createElementBlock, normalizeClass, normalizeStyle, createElementVNode, unref, renderSlot, createBlock, Teleport, withDirectives, createCommentVNode, createVNode, vShow } from "vue";
 import { normalizeFloatingTriggers, getFloatingPopupStyle } from "../utils/floating-core.js";
 import "../utils/floating.css.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
 import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
+import { useStableId } from "../utils/use-stable-id.js";
+import { useTriggerAria } from "../utils/use-trigger-aria.js";
 import { tooltipProps, tooltipEmits } from "./types.js";
 import "./style.css.js";
-const _hoisted_1 = ["aria-hidden"];
+const _hoisted_1 = ["aria-describedby"];
+const _hoisted_2 = ["id", "aria-hidden"];
 const _sfc_main = /* @__PURE__ */ defineComponent({
   ...{
     name: "ATooltip"
@@ -36,12 +39,16 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const rootRef = ref(null);
     const triggerRef = ref(null);
     const popupRef = ref(null);
+    const popupId = useStableId(void 0, "aheart-tooltip");
     const arrowRef = ref(null);
     const effectivePlacement = ref(props.placement);
     const isControlled = computed(() => props.open !== void 0);
     const mergedOpen = computed(() => props.open ?? innerOpen.value);
     const normalizedTriggers = computed(() => new Set(normalizeFloatingTriggers(props.trigger)));
     const hasTitle = computed(() => Boolean(slots.title) || hasTitleContent(props.title));
+    useTriggerAria(triggerRef, () => ({
+      "aria-describedby": hasTitle.value ? popupId.value : void 0
+    }));
     const visible = computed(() => hasTitle.value && mergedOpen.value);
     const shouldDestroyOnHidden = computed(() => props.destroyOnHidden || props.destroyTooltipOnHide);
     const motion = useMotionPresence(visible, { destroyOnHidden: shouldDestroyOnHidden, duration: 120 });
@@ -180,21 +187,30 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     };
     const handleFocusIn = () => {
       if (normalizedTriggers.value.has("focus")) {
+        clearTimers();
         requestOpen(true);
       }
     };
-    const handleFocusOut = () => {
+    const handleFocusOut = (event) => {
+      var _a, _b;
       if (normalizedTriggers.value.has("focus")) {
+        clearTimers();
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && (((_a = rootRef.value) == null ? void 0 : _a.contains(nextTarget)) || ((_b = popupRef.value) == null ? void 0 : _b.contains(nextTarget)))) {
+          return;
+        }
         requestOpen(false);
       }
     };
     const handleClick = () => {
       if (normalizedTriggers.value.has("click")) {
+        clearTimers();
         requestOpen(!mergedOpen.value);
       }
     };
     const handleContextmenu = (event) => {
       if (normalizedTriggers.value.has("contextMenu")) {
+        clearTimers();
         event.preventDefault();
         requestOpen(true);
       }
@@ -219,6 +235,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           ref_key: "triggerRef",
           ref: triggerRef,
           class: normalizeClass(["aheart-tooltip__trigger", triggerClass.value]),
+          "aria-describedby": hasTitle.value ? unref(popupId) : void 0,
           style: normalizeStyle(triggerStyle.value),
           onMouseenter: handleMouseEnter,
           onMouseleave: handleMouseLeave,
@@ -228,7 +245,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           onContextmenu: handleContextmenu
         }, [
           renderSlot(_ctx.$slots, "default")
-        ], 38),
+        ], 46, _hoisted_1),
         (openBlock(), createBlock(Teleport, {
           to: teleportTo.value,
           disabled: !shouldTeleport.value
@@ -238,11 +255,13 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             ref_key: "popupRef",
             ref: popupRef,
             class: normalizeClass(["aheart-tooltip__popup", popupClass.value]),
+            id: unref(popupId),
             style: normalizeStyle(popupStyle.value),
             role: "tooltip",
             "aria-hidden": unref(motion).phase.value === "hidden" ? "true" : void 0,
             onMouseenter: handleMouseEnter,
-            onMouseleave: handleMouseLeave
+            onMouseleave: handleMouseLeave,
+            onFocusout: handleFocusOut
           }, [
             showArrow.value ? (openBlock(), createElementBlock("span", {
               key: 0,
@@ -265,7 +284,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
                 ])
               ], 6)
             ], 6)
-          ], 46, _hoisted_1)), [
+          ], 46, _hoisted_2)), [
             [vShow, unref(motion).phase.value !== "hidden"]
           ]) : createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/es/tree-select/tree-select.vue.js
+++ b/packages/components/es/tree-select/tree-select.vue.js
@@ -1,4 +1,4 @@
-import { defineComponent, useAttrs, ref, computed, openBlock, createElementBlock, normalizeClass, createElementVNode, Fragment, renderList, toDisplayString, withModifiers, createVNode, createCommentVNode, createBlock, Teleport, unref, withDirectives, normalizeStyle, vModelText, vShow, nextTick } from "vue";
+import { defineComponent, useAttrs, ref, computed, watch, nextTick, openBlock, createElementBlock, normalizeClass, createElementVNode, Fragment, renderList, toDisplayString, withModifiers, createVNode, createCommentVNode, createBlock, Teleport, unref, withDirectives, normalizeStyle, vModelText, vShow } from "vue";
 import _sfc_main$1 from "../icon/icon.vue.js";
 import Tree from "../tree/index.js";
 import { useFloatingDismiss } from "../utils/use-floating-dismiss.js";
@@ -6,9 +6,10 @@ import { useFloatingPosition } from "../utils/use-floating-position.js";
 import { useMotionPresence } from "../utils/use-motion-presence.js";
 import { usePropPresence } from "../utils/use-prop-presence.js";
 import { useControllableState } from "../utils/use-controllable-state.js";
+import { useStableId } from "../utils/use-stable-id.js";
 import { useTeleportReady } from "../utils/use-teleport-ready.js";
 import "./style.css.js";
-const _hoisted_1 = ["id", "tabindex", "aria-expanded", "aria-disabled", "aria-labelledby"];
+const _hoisted_1 = ["id", "tabindex", "aria-expanded", "aria-disabled", "aria-labelledby", "aria-activedescendant", "aria-describedby"];
 const _hoisted_2 = {
   key: 0,
   class: "aheart-tree-select__value aheart-tree-select__tags"
@@ -19,7 +20,8 @@ const _hoisted_5 = {
   key: 0,
   class: "aheart-tree-select__tag aheart-tree-select__tag--rest"
 };
-const _hoisted_6 = {
+const _hoisted_6 = ["aria-labelledby", "aria-describedby", "aria-label"];
+const _hoisted_7 = {
   key: 1,
   class: "aheart-tree-select__empty",
   role: "status"
@@ -50,6 +52,9 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
   setup(__props, { emit: __emit }) {
     const props = __props;
     const attrs = useAttrs();
+    const instanceId = useStableId(void 0, "aheart-tree-select").value;
+    const panelId = `aheart-tree-select-panel-${instanceId}`;
+    const treeId = `aheart-tree-select-tree-${instanceId}`;
     const emit = __emit;
     const rootRef = ref(null);
     const triggerRef = ref(null);
@@ -58,6 +63,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
     const isControlled = usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence("open");
     const resolvedAriaLabelledby = computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs["aria-labelledby"]);
+    const resolvedAriaDescribedby = computed(() => attrs["aria-describedby"]);
     const openState = useControllableState({
       controlled: () => props.open,
       isControlled: isOpenControlled,
@@ -103,6 +109,34 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
       const query = searchText.value.trim().toLowerCase();
       return query ? filterNodes(props.treeData, query) : props.treeData;
     });
+    const activeKey = ref();
+    const nodeId = (key) => `${instanceId}-node-${encodeURIComponent(String(key)).replaceAll("%", "_")}`;
+    const activeNodeId = computed(() => {
+      if (!mergedOpen.value || activeKey.value === void 0)
+        return void 0;
+      return flattenNodes(filteredTreeData.value).some((node) => String(node.key) === String(activeKey.value)) ? nodeId(activeKey.value) : void 0;
+    });
+    const syncTreeNodeIds = () => {
+      var _a;
+      for (const element of Array.from(((_a = panelRef.value) == null ? void 0 : _a.querySelectorAll("[data-tree-key]")) ?? [])) {
+        const key = element.dataset.treeKey;
+        if (key !== void 0)
+          element.id = nodeId(key);
+      }
+    };
+    watch([filteredTreeData, mergedOpen], ([, open]) => {
+      if (open)
+        void nextTick(syncTreeNodeIds);
+    }, { flush: "post" });
+    const handleTreeFocusin = (event) => {
+      var _a;
+      const node = event.target.closest("[data-tree-key]");
+      if ((node == null ? void 0 : node.dataset.treeKey) !== void 0) {
+        const key = node.dataset.treeKey;
+        activeKey.value = ((_a = flattenNodes(filteredTreeData.value).find((item) => String(item.key) === key)) == null ? void 0 : _a.key) ?? key;
+        syncTreeNodeIds();
+      }
+    };
     const searchExpandedKeys = computed(() => flattenNodes(filteredTreeData.value).filter((node) => {
       var _a;
       return (_a = node.children) == null ? void 0 : _a.length;
@@ -139,8 +173,12 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
         event.preventDefault();
         requestOpen(true);
         void nextTick(() => {
-          var _a, _b;
-          return (_b = (_a = panelRef.value) == null ? void 0 : _a.querySelector('[data-tree-key][tabindex="0"]')) == null ? void 0 : _b.focus();
+          var _a;
+          syncTreeNodeIds();
+          const node = (_a = panelRef.value) == null ? void 0 : _a.querySelector('[data-tree-key][tabindex="0"]');
+          if ((node == null ? void 0 : node.dataset.treeKey) !== void 0)
+            activeKey.value = node.dataset.treeKey;
+          node == null ? void 0 : node.focus();
         });
       } else if (event.key === "Escape" && mergedOpen.value) {
         event.preventDefault();
@@ -202,6 +240,9 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
           "aria-expanded": mergedOpen.value ? "true" : "false",
           "aria-disabled": __props.disabled ? "true" : void 0,
           "aria-labelledby": resolvedAriaLabelledby.value,
+          "aria-controls": panelId,
+          "aria-activedescendant": activeNodeId.value,
+          "aria-describedby": resolvedAriaDescribedby.value,
           "aria-haspopup": "tree",
           onClick: toggleOpen,
           onKeydown: handleTriggerKeydown
@@ -260,7 +301,13 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
             ref_key: "panelRef",
             ref: panelRef,
             class: normalizeClass(["aheart-tree-select__panel", panelClass.value]),
-            style: normalizeStyle(panelStyle.value)
+            style: normalizeStyle(panelStyle.value),
+            id: panelId,
+            role: "dialog",
+            "aria-labelledby": resolvedAriaLabelledby.value || void 0,
+            "aria-describedby": resolvedAriaDescribedby.value || void 0,
+            "aria-label": resolvedAriaLabelledby.value ? void 0 : "树选择",
+            onFocusin: handleTreeFocusin
           }, [
             __props.showSearch ? withDirectives((openBlock(), createElementBlock("input", {
               key: 0,
@@ -273,6 +320,7 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
               [vModelText, searchText.value]
             ]) : createCommentVNode("", true),
             createVNode(unref(Tree), {
+              id: treeId,
               "tree-data": filteredTreeData.value,
               "selected-keys": selectedKeys.value,
               "expanded-keys": searchText.value ? searchExpandedKeys.value : void 0,
@@ -280,8 +328,8 @@ const _sfc_main = /* @__PURE__ */ defineComponent({
               disabled: __props.disabled,
               "onUpdate:selectedKeys": handleSelect
             }, null, 8, ["tree-data", "selected-keys", "expanded-keys", "multiple", "disabled"]),
-            searchText.value.trim() && filteredTreeData.value.length === 0 ? (openBlock(), createElementBlock("div", _hoisted_6, "暂无匹配节点")) : createCommentVNode("", true)
-          ], 6)), [
+            searchText.value.trim() && filteredTreeData.value.length === 0 ? (openBlock(), createElementBlock("div", _hoisted_7, "暂无匹配节点")) : createCommentVNode("", true)
+          ], 46, _hoisted_6)), [
             [vShow, unref(motion).phase.value !== "hidden"]
           ]) : createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/es/utils/overlay-controller.d.ts
+++ b/packages/components/es/utils/overlay-controller.d.ts
@@ -1,0 +1,23 @@
+export interface OverlayRegistration {
+    id: symbol;
+    document?: Document;
+    getTrigger?: () => Element | null | undefined;
+    getContent?: () => Element | null | undefined;
+    escapeEnabled?: boolean | (() => boolean);
+    getBaseZIndex?: () => number;
+    onZIndexChange?: (zIndex: number) => void;
+    onEscape?: (event: KeyboardEvent) => void;
+    onPointerDownOutside?: (event: PointerEvent) => void;
+}
+export declare const getRecentPointerTarget: (ownerDocument?: Document, maxAge?: number) => Element | null;
+export declare const refreshOverlayStack: (ownerDocument?: Document) => void;
+/** True when target is in this overlay or in an overlay opened from its content. */
+export declare const isTargetInOverlayTree: (id: symbol, target: EventTarget | null | readonly EventTarget[], ownerDocument?: Document) => boolean;
+/** Installs the lightweight input tracker before a closed blocking overlay is opened. */
+export declare const prepareOverlayDocument: (ownerDocument?: Document) => void;
+export declare const registerOverlay: (registration: OverlayRegistration) => () => void;
+export declare const updateOverlay: (id: symbol, patch: Partial<Omit<OverlayRegistration, 'id' | 'document'>>, ownerDocument?: Document) => void;
+export declare const unregisterOverlay: (id: symbol, ownerDocument?: Document) => void;
+export declare const isTopmost: (id: symbol, ownerDocument?: Document) => boolean;
+export declare const lockBodyScroll: (ownerDocument?: Document) => void;
+export declare const unlockBodyScroll: (ownerDocument?: Document) => void;

--- a/packages/components/es/utils/overlay-controller.js
+++ b/packages/components/es/utils/overlay-controller.js
@@ -1,0 +1,193 @@
+const records = /* @__PURE__ */ new WeakMap();
+const listeners = /* @__PURE__ */ new WeakMap();
+const locks = /* @__PURE__ */ new WeakMap();
+const recentPointerTargets = /* @__PURE__ */ new WeakMap();
+const INTERACTIVE_SELECTOR = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])'
+].join(",");
+const getRecords = (ownerDocument) => {
+  let value = records.get(ownerDocument);
+  if (!value) {
+    value = [];
+    records.set(ownerDocument, value);
+  }
+  return value;
+};
+const isEscapeEnabled = (record) => typeof record.escapeEnabled === "function" ? record.escapeEnabled() : record.escapeEnabled !== false;
+const getElement = (getter) => (getter == null ? void 0 : getter()) ?? null;
+const getRecentPointerTarget = (ownerDocument = document, maxAge = 500) => {
+  const recent = recentPointerTargets.get(ownerDocument);
+  return recent && Date.now() - recent.recordedAt <= maxAge ? recent.target : null;
+};
+const refreshOverlayStack = (ownerDocument = document) => {
+  var _a;
+  let previousZIndex = Number.NEGATIVE_INFINITY;
+  for (const record of getRecords(ownerDocument)) {
+    if (!record.onZIndexChange)
+      continue;
+    const baseZIndex = ((_a = record.getBaseZIndex) == null ? void 0 : _a.call(record)) ?? 0;
+    const zIndex = Number.isFinite(previousZIndex) ? Math.max(baseZIndex, previousZIndex + 10) : baseZIndex;
+    record.onZIndexChange(zIndex);
+    previousZIndex = zIndex;
+  }
+};
+const containsTarget = (record, targets) => {
+  var _a;
+  const NodeConstructor = (_a = record.document.defaultView) == null ? void 0 : _a.Node;
+  return targets.some(
+    (target) => Boolean(
+      NodeConstructor && target instanceof NodeConstructor && [getElement(record.getTrigger), getElement(record.getContent)].some((element) => element == null ? void 0 : element.contains(target))
+    )
+  );
+};
+const isTargetInOverlayTree = (id, target, ownerDocument = document) => {
+  const stack = getRecords(ownerDocument);
+  const record = stack.find((entry) => entry.id === id);
+  if (!record)
+    return false;
+  const targets = Array.isArray(target) ? target : [target];
+  if (containsTarget(record, targets))
+    return true;
+  const getParent = (child) => {
+    const childIndex = stack.indexOf(child);
+    const childTrigger = getElement(child.getTrigger);
+    const childContent = getElement(child.getContent);
+    for (let index = childIndex - 1; index >= 0; index -= 1) {
+      const candidate = stack[index];
+      const candidateContent = getElement(candidate.getContent);
+      if (candidateContent && (candidateContent.contains(childTrigger) || candidateContent.contains(childContent))) {
+        return candidate;
+      }
+    }
+  };
+  return stack.some((candidate) => {
+    if (candidate.id === id || !containsTarget(candidate, targets))
+      return false;
+    const visited = /* @__PURE__ */ new Set();
+    let parent = getParent(candidate);
+    while (parent && !visited.has(parent.id)) {
+      if (parent.id === id)
+        return true;
+      visited.add(parent.id);
+      parent = getParent(parent);
+    }
+    return false;
+  });
+};
+const ensureListeners = (ownerDocument) => {
+  if (listeners.has(ownerDocument))
+    return;
+  const keydown = (event) => {
+    var _a;
+    recentPointerTargets.delete(ownerDocument);
+    if (event.key !== "Escape")
+      return;
+    const stack = getRecords(ownerDocument);
+    const top = stack[stack.length - 1];
+    if (!top)
+      return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (isEscapeEnabled(top))
+      (_a = top.onEscape) == null ? void 0 : _a.call(top, event);
+  };
+  const pointerdown = (event) => {
+    var _a, _b, _c;
+    const ElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.Element;
+    const pathTarget = (((_b = event.composedPath) == null ? void 0 : _b.call(event)) ?? [event.target]).find(
+      (target) => ElementConstructor && target instanceof ElementConstructor
+    );
+    const pathElement = ElementConstructor && pathTarget instanceof ElementConstructor ? pathTarget : null;
+    const pointerTarget = (pathElement == null ? void 0 : pathElement.closest(INTERACTIVE_SELECTOR)) ?? pathElement;
+    if (pointerTarget)
+      recentPointerTargets.set(ownerDocument, { target: pointerTarget, recordedAt: Date.now() });
+    const stack = getRecords(ownerDocument);
+    const top = stack[stack.length - 1];
+    const path = ((_c = event.composedPath) == null ? void 0 : _c.call(event)) ?? [event.target];
+    if (!top || !top.onPointerDownOutside || isTargetInOverlayTree(top.id, path, ownerDocument))
+      return;
+    top.onPointerDownOutside(event);
+  };
+  ownerDocument.addEventListener("keydown", keydown, true);
+  ownerDocument.addEventListener("pointerdown", pointerdown, true);
+  listeners.set(ownerDocument, { keydown, pointerdown });
+};
+const prepareOverlayDocument = (ownerDocument = document) => {
+  ensureListeners(ownerDocument);
+};
+const registerOverlay = (registration) => {
+  const ownerDocument = registration.document ?? document;
+  const stack = getRecords(ownerDocument);
+  const existing = stack.findIndex((entry) => entry.id === registration.id);
+  if (existing >= 0)
+    stack.splice(existing, 1);
+  stack.push({ ...registration, document: ownerDocument });
+  refreshOverlayStack(ownerDocument);
+  ensureListeners(ownerDocument);
+  return () => unregisterOverlay(registration.id, ownerDocument);
+};
+const unregisterOverlay = (id, ownerDocument = document) => {
+  const stack = getRecords(ownerDocument);
+  const index = stack.findIndex((entry) => entry.id === id);
+  if (index >= 0)
+    stack.splice(index, 1);
+  refreshOverlayStack(ownerDocument);
+  if (stack.length === 0) {
+    records.delete(ownerDocument);
+  }
+};
+const isTopmost = (id, ownerDocument = document) => {
+  var _a;
+  const stack = getRecords(ownerDocument);
+  return ((_a = stack[stack.length - 1]) == null ? void 0 : _a.id) === id;
+};
+const lockBodyScroll = (ownerDocument = document) => {
+  var _a, _b;
+  const body = ownerDocument.body;
+  if (!body)
+    return;
+  const state = locks.get(ownerDocument);
+  if (state) {
+    state.count += 1;
+    return;
+  }
+  const paddingRight = body.style.paddingRight;
+  const viewportWidth = ((_a = ownerDocument.defaultView) == null ? void 0 : _a.innerWidth) ?? 0;
+  const contentWidth = ownerDocument.documentElement.clientWidth;
+  const scrollbarWidth = contentWidth > 0 ? Math.max(0, viewportWidth - contentWidth) : 0;
+  locks.set(ownerDocument, { count: 1, overflow: body.style.overflow, paddingRight });
+  if (scrollbarWidth > 0) {
+    const currentPadding = Number.parseFloat(((_b = ownerDocument.defaultView) == null ? void 0 : _b.getComputedStyle(body).paddingRight) ?? "0") || 0;
+    body.style.paddingRight = `${currentPadding + scrollbarWidth}px`;
+  }
+  body.style.overflow = "hidden";
+};
+const unlockBodyScroll = (ownerDocument = document) => {
+  const state = locks.get(ownerDocument);
+  if (!state)
+    return;
+  state.count -= 1;
+  if (state.count > 0)
+    return;
+  if (ownerDocument.body) {
+    ownerDocument.body.style.overflow = state.overflow;
+    ownerDocument.body.style.paddingRight = state.paddingRight;
+  }
+  locks.delete(ownerDocument);
+};
+export {
+  getRecentPointerTarget,
+  isTargetInOverlayTree,
+  isTopmost,
+  lockBodyScroll,
+  prepareOverlayDocument,
+  refreshOverlayStack,
+  registerOverlay,
+  unlockBodyScroll,
+  unregisterOverlay
+};

--- a/packages/components/es/utils/use-floating-dismiss.js
+++ b/packages/components/es/utils/use-floating-dismiss.js
@@ -1,9 +1,14 @@
 import { watchEffect, toValue, onScopeDispose, nextTick } from "vue";
+import { registerOverlay } from "./overlay-controller.js";
 function useFloatingDismiss(options) {
-  let removeListeners;
+  const overlayId = Symbol("aheart-floating-overlay");
+  let unregister;
+  let restoreZIndex;
   const cleanup = () => {
-    removeListeners == null ? void 0 : removeListeners();
-    removeListeners = void 0;
+    unregister == null ? void 0 : unregister();
+    unregister = void 0;
+    restoreZIndex == null ? void 0 : restoreZIndex();
+    restoreZIndex = void 0;
   };
   const focusTrigger = () => {
     const trigger = toValue(options.trigger);
@@ -21,38 +26,51 @@ function useFloatingDismiss(options) {
     target == null ? void 0 : target.focus();
   };
   watchEffect((onCleanup) => {
+    var _a, _b;
     cleanup();
     if (typeof document === "undefined" || !toValue(options.open)) {
       return;
     }
-    const handlePointerDown = (event) => {
-      const trigger = toValue(options.trigger);
-      const floating = toValue(options.floating);
-      const path = event.composedPath();
-      if (trigger && path.includes(trigger) || floating && path.includes(floating)) {
-        return;
+    const trigger = toValue(options.trigger);
+    const floating = toValue(options.floating);
+    const ownerDocument = (trigger == null ? void 0 : trigger.ownerDocument) ?? (floating == null ? void 0 : floating.ownerDocument) ?? document;
+    const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+    const floatingElement = HTMLElementConstructor && floating instanceof HTMLElementConstructor ? floating : null;
+    const originalZIndex = (floatingElement == null ? void 0 : floatingElement.style.zIndex) ?? "";
+    const computedZIndex = Number.parseFloat(
+      floatingElement ? ((_b = ownerDocument.defaultView) == null ? void 0 : _b.getComputedStyle(floatingElement).zIndex) ?? "" : ""
+    );
+    const baseZIndex = Number.isFinite(computedZIndex) ? computedZIndex : 0;
+    restoreZIndex = floatingElement ? () => {
+      floatingElement.style.zIndex = originalZIndex;
+    } : void 0;
+    unregister = registerOverlay({
+      id: overlayId,
+      document: ownerDocument,
+      getTrigger: () => toValue(options.trigger),
+      getContent: () => toValue(options.floating),
+      escapeEnabled: () => toValue(options.open),
+      getBaseZIndex: () => baseZIndex,
+      onZIndexChange: (zIndex) => {
+        const content = toValue(options.floating);
+        if (HTMLElementConstructor && content instanceof HTMLElementConstructor) {
+          content.style.zIndex = String(zIndex);
+        }
+      },
+      onPointerDownOutside: (event) => {
+        if (toValue(options.open))
+          options.onDismiss("outside", event);
+      },
+      onEscape: (event) => {
+        options.onDismiss("escape", event);
+        if (toValue(options.restoreFocus) !== false) {
+          void nextTick(() => {
+            if (!toValue(options.open))
+              focusTrigger();
+          });
+        }
       }
-      options.onDismiss("outside", event);
-    };
-    const handleKeydown = (event) => {
-      if (event.key !== "Escape") {
-        return;
-      }
-      event.preventDefault();
-      options.onDismiss("escape", event);
-      if (toValue(options.restoreFocus) !== false) {
-        void nextTick(() => {
-          if (!toValue(options.open))
-            focusTrigger();
-        });
-      }
-    };
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    document.addEventListener("keydown", handleKeydown, true);
-    removeListeners = () => {
-      document.removeEventListener("pointerdown", handlePointerDown, true);
-      document.removeEventListener("keydown", handleKeydown, true);
-    };
+    });
     onCleanup(cleanup);
   });
   onScopeDispose(cleanup);

--- a/packages/components/es/utils/use-trigger-aria.d.ts
+++ b/packages/components/es/utils/use-trigger-aria.d.ts
@@ -1,0 +1,6 @@
+import { type MaybeRefOrGetter } from 'vue';
+type TriggerAriaValue = string | undefined;
+type TriggerAriaAttributes = Record<`aria-${string}`, TriggerAriaValue>;
+/** Mirrors wrapper-owned popup relationships onto the actual slotted focus target. */
+export declare const useTriggerAria: (rootSource: MaybeRefOrGetter<HTMLElement | null | undefined>, getAttributes: () => TriggerAriaAttributes) => void;
+export {};

--- a/packages/components/es/utils/use-trigger-aria.js
+++ b/packages/components/es/utils/use-trigger-aria.js
@@ -1,0 +1,64 @@
+import { watchEffect, toValue, nextTick, onScopeDispose } from "vue";
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])'
+].join(",");
+const TOKEN_ATTRIBUTES = /* @__PURE__ */ new Set(["aria-describedby", "aria-labelledby"]);
+const useTriggerAria = (rootSource, getAttributes) => {
+  let sequence = 0;
+  let target = null;
+  let originals = /* @__PURE__ */ new Map();
+  const restore = () => {
+    if (!target)
+      return;
+    for (const [name, value] of originals) {
+      if (value === null)
+        target.removeAttribute(name);
+      else
+        target.setAttribute(name, value);
+    }
+    target = null;
+    originals = /* @__PURE__ */ new Map();
+  };
+  watchEffect(() => {
+    const root = toValue(rootSource);
+    const attributes = getAttributes();
+    const currentSequence = ++sequence;
+    void nextTick(() => {
+      if (currentSequence !== sequence)
+        return;
+      const nextTarget = (root == null ? void 0 : root.matches(FOCUSABLE_SELECTOR)) ? root : (root == null ? void 0 : root.querySelector(FOCUSABLE_SELECTOR)) ?? null;
+      if (nextTarget !== target) {
+        restore();
+        target = nextTarget;
+      }
+      if (!target)
+        return;
+      for (const [name, value] of Object.entries(attributes)) {
+        if (!originals.has(name))
+          originals.set(name, target.getAttribute(name));
+        const original = originals.get(name);
+        if (value === void 0) {
+          if (original === null)
+            target.removeAttribute(name);
+          else if (original !== void 0)
+            target.setAttribute(name, original);
+          continue;
+        }
+        const resolvedValue = TOKEN_ATTRIBUTES.has(name) && original ? Array.from(/* @__PURE__ */ new Set([...original.split(/\s+/), value])).join(" ") : value;
+        target.setAttribute(name, resolvedValue);
+      }
+    });
+  });
+  onScopeDispose(() => {
+    sequence += 1;
+    restore();
+  });
+};
+export {
+  useTriggerAria
+};

--- a/packages/components/lib/cascader/cascader.vue.js
+++ b/packages/components/lib/cascader/cascader.vue.js
@@ -7,9 +7,10 @@ const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
 const useControllableState = require("../utils/use-controllable-state.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 require("./style.css.js");
-const _hoisted_1 = ["tabindex", "aria-expanded", "aria-disabled"];
+const _hoisted_1 = ["tabindex", "aria-expanded", "aria-disabled", "aria-activedescendant", "aria-labelledby", "aria-describedby"];
 const _hoisted_2 = {
   key: 0,
   class: "aheart-cascader__value aheart-cascader__tags"
@@ -20,17 +21,18 @@ const _hoisted_5 = {
   key: 0,
   class: "aheart-cascader__tag aheart-cascader__tag--rest"
 };
-const _hoisted_6 = {
+const _hoisted_6 = ["aria-labelledby", "aria-describedby", "aria-label"];
+const _hoisted_7 = {
   key: 1,
   class: "aheart-cascader__search-results"
 };
-const _hoisted_7 = ["data-cascader-path", "disabled", "onClick"];
-const _hoisted_8 = {
+const _hoisted_8 = ["data-cascader-path", "disabled", "onClick"];
+const _hoisted_9 = {
   key: 0,
   class: "aheart-cascader__empty",
   role: "status"
 };
-const _hoisted_9 = ["data-cascader-value", "disabled", "aria-busy", "onClick"];
+const _hoisted_10 = ["data-cascader-value", "id", "data-cascader-column", "disabled", "aria-busy", "onClick", "onFocus"];
 const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   ...{ name: "ACascader" },
   __name: "cascader",
@@ -59,12 +61,15 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       ...option,
       children: option.children ? cloneOptions(option.children) : void 0
     }));
+    const instanceId = useStableId.useStableId(void 0, "aheart-cascader").value;
+    const panelId = `aheart-cascader-panel-${instanceId}`;
     const rootRef = vue.ref(null);
     const triggerRef = vue.ref(null);
     const panelRef = vue.ref(null);
     const columnsRef = vue.ref(null);
     const searchText = vue.ref("");
     const activePath = vue.ref([]);
+    const focusedPath = vue.ref([]);
     const loadingPaths = vue.ref([]);
     const innerOptions = vue.ref(cloneOptions(props.options));
     const isControlled = usePropPresence.usePropPresence("modelValue", "model-value");
@@ -167,6 +172,25 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       const query = searchText.value.trim().toLowerCase();
       return collectLeaves(innerOptions.value).filter((result) => result.labels.join(" / ").toLowerCase().includes(query));
     });
+    const attrs = vue.useAttrs();
+    const resolvedAriaLabelledby = vue.computed(() => attrs["aria-labelledby"]);
+    const resolvedAriaDescribedby = vue.computed(() => attrs["aria-describedby"]);
+    const optionId = (option, columnIndex) => {
+      var _a;
+      return `${instanceId}-option-${columnIndex}-${Math.max(0, ((_a = columns.value[columnIndex]) == null ? void 0 : _a.indexOf(option)) ?? 0)}`;
+    };
+    const activeDescendantId = vue.computed(() => {
+      var _a, _b, _c;
+      if (!mergedOpen.value || searchText.value.trim())
+        return void 0;
+      const path = focusedPath.value;
+      if (!path.length)
+        return void 0;
+      const option = ((_b = (_a = findOption(path.slice(0, -1))) == null ? void 0 : _a.children) == null ? void 0 : _b.find((item) => item.value === path.at(-1))) ?? (path.length === 1 ? innerOptions.value.find((item) => item.value === path[0]) : void 0);
+      if (!option || !((_c = columns.value[path.length - 1]) == null ? void 0 : _c.includes(option)))
+        return void 0;
+      return optionId(option, path.length - 1);
+    });
     const isSelected = (columnIndex, option) => selectedPaths.value.some((path) => path[columnIndex] === option.value && path.length === columnIndex + 1);
     const isLoading = (columnIndex, option) => loadingPaths.value.some((path) => samePath(path, [...activePath.value.slice(0, columnIndex), option.value]));
     const requestOpen = (open) => {
@@ -238,6 +262,9 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         }
       }
     };
+    const handleOptionFocus = (option, columnIndex) => {
+      focusedPath.value = [...activePath.value.slice(0, columnIndex), option.value];
+    };
     const handleTriggerKeydown = (event) => {
       if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
         event.preventDefault();
@@ -256,13 +283,15 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       }
     };
     const handleOptionKeydown = (event) => {
-      var _a, _b;
+      var _a, _b, _c, _d, _e, _f;
       const current = event.currentTarget;
       const options = Array.from(((_a = current.parentElement) == null ? void 0 : _a.querySelectorAll(".aheart-cascader__option:not(:disabled)")) ?? []);
       const index = options.indexOf(current);
+      const columnIndex = Number(current.dataset.cascaderColumn);
+      const option = (_b = columns.value[columnIndex]) == null ? void 0 : _b.find((item) => String(item.value) === current.dataset.cascaderValue);
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
-        (_b = options[(index + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length]) == null ? void 0 : _b.focus();
+        (_c = options[(index + (event.key === "ArrowDown" ? 1 : -1) + options.length) % options.length]) == null ? void 0 : _c.focus();
       } else if (event.key === "Escape") {
         event.preventDefault();
         requestOpen(false);
@@ -270,6 +299,19 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           var _a2;
           return (_a2 = triggerRef.value) == null ? void 0 : _a2.focus();
         });
+      } else if (event.key === "Home" || event.key === "End") {
+        event.preventDefault();
+        (_d = options[event.key === "Home" ? 0 : options.length - 1]) == null ? void 0 : _d.focus();
+      } else if (event.key === "ArrowRight" && option && isBranch(option)) {
+        event.preventDefault();
+        void handleOption(option, columnIndex).then(() => vue.nextTick(() => {
+          var _a2, _b2;
+          return (_b2 = (_a2 = panelRef.value) == null ? void 0 : _a2.querySelector(`[data-cascader-column="${columnIndex + 1}"]:not(:disabled)`)) == null ? void 0 : _b2.focus();
+        }));
+      } else if (event.key === "ArrowLeft" && columnIndex > 0) {
+        event.preventDefault();
+        const parentValue = focusedPath.value[columnIndex - 1] ?? activePath.value[columnIndex - 1];
+        (_f = Array.from(((_e = panelRef.value) == null ? void 0 : _e.querySelectorAll(`[data-cascader-column="${columnIndex - 1}"]`)) ?? []).find((element) => element.dataset.cascaderValue === String(parentValue))) == null ? void 0 : _f.focus();
       }
     };
     const motion = useMotionPresence.useMotionPresence(mergedOpen, { destroyOnHidden: true, duration: 120 });
@@ -315,6 +357,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           tabindex: __props.disabled ? -1 : 0,
           "aria-expanded": mergedOpen.value ? "true" : "false",
           "aria-disabled": __props.disabled ? "true" : void 0,
+          "aria-controls": panelId,
+          "aria-activedescendant": activeDescendantId.value,
+          "aria-labelledby": resolvedAriaLabelledby.value,
+          "aria-describedby": resolvedAriaDescribedby.value,
           "aria-haspopup": "dialog",
           onClick: toggleOpen,
           onKeydown: handleTriggerKeydown
@@ -375,7 +421,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             class: vue.normalizeClass(["aheart-cascader__panel", panelClass.value]),
             style: vue.normalizeStyle(panelStyle.value),
             role: "dialog",
-            "aria-label": "级联选择"
+            id: panelId,
+            "aria-labelledby": resolvedAriaLabelledby.value || void 0,
+            "aria-describedby": resolvedAriaDescribedby.value || void 0,
+            "aria-label": resolvedAriaLabelledby.value ? void 0 : "级联选择"
           }, [
             __props.showSearch ? vue.withDirectives((vue.openBlock(), vue.createElementBlock("input", {
               key: 0,
@@ -387,7 +436,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             }, null, 512)), [
               [vue.vModelText, searchText.value]
             ]) : vue.createCommentVNode("", true),
-            searchText.value.trim() ? (vue.openBlock(), vue.createElementBlock("div", _hoisted_6, [
+            searchText.value.trim() ? (vue.openBlock(), vue.createElementBlock("div", _hoisted_7, [
               (vue.openBlock(true), vue.createElementBlock(vue.Fragment, null, vue.renderList(searchResults.value, (result) => {
                 return vue.openBlock(), vue.createElementBlock("button", {
                   key: pathKey(result.path),
@@ -396,9 +445,9 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                   "data-cascader-path": pathKey(result.path),
                   disabled: __props.disabled || result.disabled,
                   onClick: ($event) => selectPath(result.path)
-                }, vue.toDisplayString(result.labels.join(" / ")), 9, _hoisted_7);
+                }, vue.toDisplayString(result.labels.join(" / ")), 9, _hoisted_8);
               }), 128)),
-              searchResults.value.length === 0 ? (vue.openBlock(), vue.createElementBlock("div", _hoisted_8, "暂无匹配选项")) : vue.createCommentVNode("", true)
+              searchResults.value.length === 0 ? (vue.openBlock(), vue.createElementBlock("div", _hoisted_9, "暂无匹配选项")) : vue.createCommentVNode("", true)
             ])) : (vue.openBlock(), vue.createElementBlock("div", {
               key: 2,
               ref_key: "columnsRef",
@@ -416,9 +465,12 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                       class: vue.normalizeClass(["aheart-cascader__option", { "is-active": activePath.value[columnIndex] === option.value, "is-selected": isSelected(columnIndex, option), "is-loading": isLoading(columnIndex, option) }]),
                       type: "button",
                       "data-cascader-value": option.value,
+                      id: optionId(option, columnIndex),
+                      "data-cascader-column": columnIndex,
                       disabled: __props.disabled || option.disabled || isLoading(columnIndex, option),
                       "aria-busy": isLoading(columnIndex, option) ? "true" : void 0,
                       onClick: ($event) => handleOption(option, columnIndex),
+                      onFocus: ($event) => handleOptionFocus(option, columnIndex),
                       onKeydown: handleOptionKeydown
                     }, [
                       vue.createElementVNode("span", null, vue.toDisplayString(option.label), 1),
@@ -434,12 +486,12 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                         size: 16,
                         "aria-hidden": "true"
                       })) : vue.createCommentVNode("", true)
-                    ], 42, _hoisted_9);
+                    ], 42, _hoisted_10);
                   }), 128))
                 ]);
               }), 128))
             ], 512))
-          ], 6)), [
+          ], 14, _hoisted_6)), [
             [vue.vShow, vue.unref(motion).phase.value !== "hidden"]
           ]) : vue.createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/lib/drawer/drawer.vue.js
+++ b/packages/components/lib/drawer/drawer.vue.js
@@ -5,6 +5,7 @@ const index = require("../skeleton/index.js");
 const usePointerDrag = require("../utils/use-pointer-drag.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
+const overlayController = require("../utils/overlay-controller.js");
 const types = require("./types.js");
 require("./style.css.js");
 const _hoisted_1 = ["aria-hidden"];
@@ -68,10 +69,48 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const leaveFocusElement = vue.ref(null);
     const titleId = `aheart-drawer-title-${(instance == null ? void 0 : instance.uid) ?? "dialog"}`;
     let pendingCloseCompletion = false;
+    let overlayRegistered = false;
+    const drawerId = Symbol("ADrawer");
+    let overlayDocument = null;
+    const effectiveZIndex = vue.ref(props.zIndex);
     const resizedSize = vue.ref();
     const resizeStart = vue.ref(null);
+    const getDrawerDocument = () => {
+      var _a, _b;
+      const target = teleportTarget.value;
+      return ((_a = panelRef.value) == null ? void 0 : _a.ownerDocument) ?? ((_b = triggerElement.value) == null ? void 0 : _b.ownerDocument) ?? (typeof target === "object" && target ? target.ownerDocument : document);
+    };
+    const isDrawerTopmost = () => overlayController.isTopmost(drawerId, overlayDocument ?? getDrawerDocument());
+    const registerDrawerOverlay = () => {
+      if (overlayRegistered)
+        return;
+      const ownerDocument = getDrawerDocument();
+      overlayController.registerOverlay({
+        id: drawerId,
+        document: ownerDocument,
+        getTrigger: () => triggerElement.value,
+        getContent: () => panelRef.value,
+        escapeEnabled: () => props.open && props.keyboard,
+        getBaseZIndex: () => props.zIndex,
+        onZIndexChange: (zIndex) => {
+          effectiveZIndex.value = zIndex;
+        },
+        onEscape: close
+      });
+      overlayController.lockBodyScroll(ownerDocument);
+      overlayDocument = ownerDocument;
+      overlayRegistered = true;
+    };
+    const unregisterDrawerOverlay = () => {
+      if (!overlayRegistered)
+        return;
+      const ownerDocument = overlayDocument ?? getDrawerDocument();
+      overlayController.unregisterOverlay(drawerId, ownerDocument);
+      overlayController.unlockBodyScroll(ownerDocument);
+      overlayDocument = null;
+      overlayRegistered = false;
+    };
     const parentPushContext = vue.inject(DRAWER_PUSH_CONTEXT, null);
-    const drawerId = Symbol("ADrawer");
     const openChildDrawers = vue.ref(/* @__PURE__ */ new Map());
     const setChildOpen = (id, open) => {
       const nextOpenChildren = new Map(openChildDrawers.value);
@@ -243,7 +282,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const rootStyle = vue.computed(() => ({
       ...props.rootStyle,
       ...semanticStyle("root"),
-      zIndex: props.zIndex
+      zIndex: effectiveZIndex.value
     }));
     const mergedMaskStyle = vue.computed(() => ({
       ...props.maskStyle,
@@ -297,20 +336,23 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     vue.watch(
       () => props.open,
       (open, previousOpen) => {
-        var _a;
+        var _a, _b;
         if (open && !previousOpen) {
           pendingCloseCompletion = false;
           leaveFocusElement.value = null;
           if (motion.phase.value === "hidden")
             captureTriggerElement();
+          registerDrawerOverlay();
           emit("afterOpenChange", true);
         }
         if (!open) {
           pendingCloseCompletion = true;
-          const activeElement = document.activeElement;
-          leaveFocusElement.value = activeElement instanceof HTMLElement && ((_a = panelRef.value) == null ? void 0 : _a.contains(activeElement)) ? activeElement : null;
+          const ownerDocument = overlayDocument ?? getDrawerDocument();
+          const activeElement = ownerDocument.activeElement;
+          const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+          leaveFocusElement.value = HTMLElementConstructor && activeElement instanceof HTMLElementConstructor && ((_b = panelRef.value) == null ? void 0 : _b.contains(activeElement)) ? activeElement : null;
           void vue.nextTick(() => {
-            if (motion.phase.value === "leave" && leaveFocusElement.value && document.contains(leaveFocusElement.value)) {
+            if (motion.phase.value === "leave" && leaveFocusElement.value && ownerDocument.contains(leaveFocusElement.value)) {
               leaveFocusElement.value.focus();
             }
           });
@@ -319,13 +361,24 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       { flush: "sync" }
     );
     vue.watch(
+      () => props.zIndex,
+      (zIndex) => {
+        if (overlayRegistered)
+          overlayController.refreshOverlayStack(overlayDocument ?? getDrawerDocument());
+        else
+          effectiveZIndex.value = zIndex;
+      }
+    );
+    vue.watch(
       () => motion.phase.value,
       (phase) => {
         if (phase === "entered" && props.open) {
-          void vue.nextTick(() => focusPanel());
+          if (isDrawerTopmost())
+            void vue.nextTick(() => focusPanel());
           return;
         }
         if (phase === "hidden" && !props.open && pendingCloseCompletion) {
+          unregisterDrawerOverlay();
           pendingCloseCompletion = false;
           emit("afterOpenChange", false);
           void vue.nextTick(() => restoreTriggerFocus());
@@ -340,7 +393,12 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       },
       { immediate: true }
     );
+    vue.onBeforeMount(() => {
+      if (props.open)
+        registerDrawerOverlay();
+    });
     vue.onBeforeUnmount(() => {
+      unregisterDrawerOverlay();
       parentPushContext == null ? void 0 : parentPushContext.setChildOpen(drawerId, false);
     });
     const resolveSemanticConfig = (config, part) => {
@@ -350,16 +408,20 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const semanticClass = (part) => resolveSemanticConfig(props.classNames, part);
     const semanticStyle = (part) => resolveSemanticConfig(props.styles, part);
     const captureTriggerElement = () => {
-      triggerElement.value = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      var _a;
+      const ownerDocument = getDrawerDocument();
+      const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+      const pointerTarget = overlayController.getRecentPointerTarget(ownerDocument);
+      triggerElement.value = HTMLElementConstructor && pointerTarget instanceof HTMLElementConstructor ? pointerTarget : HTMLElementConstructor && ownerDocument.activeElement instanceof HTMLElementConstructor ? ownerDocument.activeElement : null;
     };
     const restoreTriggerFocus = () => {
       const target = triggerElement.value;
-      if (!shouldFocusTriggerAfterClose.value || !target || !document.contains(target)) {
+      if (!shouldFocusTriggerAfterClose.value || !target || !target.ownerDocument.contains(target)) {
         return;
       }
       target.focus();
     };
-    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element instanceof HTMLInputElement && element.type === "hidden");
+    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element.tagName === "INPUT" && element.type === "hidden");
     const getFocusableElements = () => {
       const panel = panelRef.value;
       if (!panel) {
@@ -368,7 +430,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       return Array.from(panel.querySelectorAll(FOCUSABLE_SELECTOR)).filter(isFocusableElementAvailable);
     };
     const focusPanel = () => {
-      if (!props.open) {
+      if (!props.open || !isDrawerTopmost()) {
         return;
       }
       const panel = panelRef.value;
@@ -376,6 +438,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       target == null ? void 0 : target.focus();
     };
     vue.onMounted(() => {
+      overlayController.prepareOverlayDocument(getDrawerDocument());
       if (!props.open) {
         return;
       }
@@ -383,7 +446,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       focusPanel();
     });
     const handleTrapTab = (event) => {
-      if (!props.open || !shouldTrapFocus.value || event.key !== "Tab") {
+      if (!props.open || !isDrawerTopmost() || !shouldTrapFocus.value || event.key !== "Tab") {
         return;
       }
       const panel = panelRef.value;
@@ -393,7 +456,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       const focusableElements = getFocusableElements();
       const firstElement = focusableElements[0] ?? panel;
       const lastElement = focusableElements[focusableElements.length - 1] ?? panel;
-      const activeElement = document.activeElement;
+      const activeElement = panel.ownerDocument.activeElement;
       if (event.shiftKey) {
         if (activeElement === firstElement || !panel.contains(activeElement)) {
           event.preventDefault();
@@ -485,7 +548,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     const handleKeydown = (event) => {
       handleTrapTab(event);
-      if (props.keyboard && event.key === "Escape") {
+      const ownerDocument = overlayDocument ?? getDrawerDocument();
+      if (!event.composedPath().includes(ownerDocument) && props.open && props.keyboard && event.key === "Escape" && isDrawerTopmost()) {
+        event.preventDefault();
+        event.stopPropagation();
         close();
       }
     };

--- a/packages/components/lib/dropdown/dropdown.vue.js
+++ b/packages/components/lib/dropdown/dropdown.vue.js
@@ -223,6 +223,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       if (!triggerSet.value.has("click")) {
         return;
       }
+      clearHoverTimers();
       setOpen(!mergedOpen.value, { source: "trigger" });
     };
     const handleMouseEnter = () => {
@@ -241,6 +242,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     const handleContextmenu = (event) => {
       if (triggerSet.value.has("contextMenu")) {
+        clearHoverTimers();
         event.preventDefault();
         setOpen(true, { source: "trigger" });
       }

--- a/packages/components/lib/modal/modal.vue.js
+++ b/packages/components/lib/modal/modal.vue.js
@@ -6,24 +6,12 @@ const index = require("../skeleton/index.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 const types = require("./types.js");
+const overlayController = require("../utils/overlay-controller.js");
 require("./style.css.js");
 const context = require("../config/context.js");
 const _hoisted_1 = ["aria-hidden"];
 const _hoisted_2 = ["aria-label", "aria-labelledby"];
 const _hoisted_3 = ["disabled", "aria-label"];
-const openModalStack = [];
-const registerOpenModal = (id) => {
-  const previousIndex = openModalStack.indexOf(id);
-  if (previousIndex >= 0)
-    openModalStack.splice(previousIndex, 1);
-  openModalStack.push(id);
-};
-const unregisterOpenModal = (id) => {
-  const index2 = openModalStack.indexOf(id);
-  if (index2 >= 0)
-    openModalStack.splice(index2, 1);
-};
-const isTopmostOpenModal = (id) => openModalStack[openModalStack.length - 1] === id;
 const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   ...{
     name: "AModal"
@@ -57,6 +45,44 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const modalStackId = Symbol("aheart-modal");
     const titleId = `aheart-modal-title-${(instance == null ? void 0 : instance.uid) ?? "dialog"}`;
     let pendingCloseCompletion = false;
+    let overlayRegistered = false;
+    let overlayDocument = null;
+    const effectiveZIndex = vue.ref(props.zIndex);
+    const getModalDocument = () => {
+      var _a, _b;
+      const target = teleportTarget.value;
+      return ((_a = dialogRef.value) == null ? void 0 : _a.ownerDocument) ?? ((_b = triggerElement.value) == null ? void 0 : _b.ownerDocument) ?? (typeof target === "object" && target ? target.ownerDocument : document);
+    };
+    const isModalTopmost = () => overlayController.isTopmost(modalStackId, overlayDocument ?? getModalDocument());
+    const registerModalOverlay = () => {
+      if (overlayRegistered)
+        return;
+      const ownerDocument = getModalDocument();
+      overlayController.registerOverlay({
+        id: modalStackId,
+        document: ownerDocument,
+        getTrigger: () => triggerElement.value,
+        getContent: () => dialogRef.value,
+        escapeEnabled: () => props.open && props.keyboard,
+        getBaseZIndex: () => props.zIndex,
+        onZIndexChange: (zIndex) => {
+          effectiveZIndex.value = zIndex;
+        },
+        onEscape: close
+      });
+      overlayController.lockBodyScroll(ownerDocument);
+      overlayDocument = ownerDocument;
+      overlayRegistered = true;
+    };
+    const unregisterModalOverlay = () => {
+      if (!overlayRegistered)
+        return;
+      const ownerDocument = overlayDocument ?? getModalDocument();
+      overlayController.unregisterOverlay(modalStackId, ownerDocument);
+      overlayController.unlockBodyScroll(ownerDocument);
+      overlayDocument = null;
+      overlayRegistered = false;
+    };
     const AModalRenderNode = vue.defineComponent({
       name: "AModalRenderNode",
       props: {
@@ -138,7 +164,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const rootStyle = vue.computed(() => ({
       ...props.rootStyle,
       ...semanticStyle("root"),
-      zIndex: props.zIndex
+      zIndex: effectiveZIndex.value
     }));
     const hasTitle = vue.computed(() => Boolean(slots.title) || hasRenderable(props.title));
     const hasHeader = vue.computed(() => hasTitle.value || showCloseButton.value);
@@ -277,22 +303,23 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     vue.watch(
       () => props.open,
       (open, previousOpen) => {
-        var _a;
+        var _a, _b;
         if (open && !previousOpen) {
-          registerOpenModal(modalStackId);
           pendingCloseCompletion = false;
           leaveFocusElement.value = null;
           if (motion.phase.value === "hidden")
             captureTriggerElement();
+          registerModalOverlay();
           emit("afterOpenChange", true);
         }
         if (!open) {
-          unregisterOpenModal(modalStackId);
           pendingCloseCompletion = true;
-          const activeElement = document.activeElement;
-          leaveFocusElement.value = activeElement instanceof HTMLElement && ((_a = dialogRef.value) == null ? void 0 : _a.contains(activeElement)) ? activeElement : null;
+          const ownerDocument = overlayDocument ?? getModalDocument();
+          const activeElement = ownerDocument.activeElement;
+          const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+          leaveFocusElement.value = HTMLElementConstructor && activeElement instanceof HTMLElementConstructor && ((_b = dialogRef.value) == null ? void 0 : _b.contains(activeElement)) ? activeElement : null;
           void vue.nextTick(() => {
-            if (motion.phase.value === "leave" && leaveFocusElement.value && document.contains(leaveFocusElement.value)) {
+            if (motion.phase.value === "leave" && leaveFocusElement.value && ownerDocument.contains(leaveFocusElement.value)) {
               leaveFocusElement.value.focus();
             }
           });
@@ -301,9 +328,18 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       { flush: "sync" }
     );
     vue.watch(
+      () => props.zIndex,
+      (zIndex) => {
+        if (overlayRegistered)
+          overlayController.refreshOverlayStack(overlayDocument ?? getModalDocument());
+        else
+          effectiveZIndex.value = zIndex;
+      }
+    );
+    vue.watch(
       () => props.open,
       (open) => {
-        if (open && isTopmostOpenModal(modalStackId))
+        if (open && isModalTopmost())
           focusDialog();
       },
       { flush: "post" }
@@ -312,11 +348,12 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       () => motion.phase.value,
       (phase) => {
         var _a, _b;
-        if (phase === "entered" && props.open && isTopmostOpenModal(modalStackId)) {
+        if (phase === "entered" && props.open && isModalTopmost()) {
           void vue.nextTick(() => focusDialog());
           return;
         }
         if (phase === "hidden" && !props.open && pendingCloseCompletion) {
+          unregisterModalOverlay();
           pendingCloseCompletion = false;
           emit("afterOpenChange", false);
           emit("afterClose");
@@ -344,16 +381,20 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       return Object.keys(merged).length > 0 ? merged : void 0;
     };
     const captureTriggerElement = () => {
-      triggerElement.value = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      var _a;
+      const ownerDocument = getModalDocument();
+      const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+      const pointerTarget = overlayController.getRecentPointerTarget(ownerDocument);
+      triggerElement.value = HTMLElementConstructor && pointerTarget instanceof HTMLElementConstructor ? pointerTarget : HTMLElementConstructor && ownerDocument.activeElement instanceof HTMLElementConstructor ? ownerDocument.activeElement : null;
     };
     const restoreTriggerFocus = () => {
       const target = triggerElement.value;
-      if (!shouldFocusTriggerAfterClose.value || !target || !document.contains(target)) {
+      if (!shouldFocusTriggerAfterClose.value || !target || !target.ownerDocument.contains(target)) {
         return;
       }
       target.focus();
     };
-    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element instanceof HTMLInputElement && element.type === "hidden");
+    const isFocusableElementAvailable = (element) => !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true" && element.tabIndex >= 0 && !(element.tagName === "INPUT" && element.type === "hidden");
     const getFocusableElements = () => {
       const dialog = dialogRef.value;
       if (!dialog) {
@@ -371,22 +412,21 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     vue.onBeforeMount(() => {
       if (props.open)
-        registerOpenModal(modalStackId);
+        registerModalOverlay();
     });
     vue.onMounted(() => {
-      document.addEventListener("keydown", handleEnteringKeydown);
-      if (!props.open || !isTopmostOpenModal(modalStackId)) {
+      overlayController.prepareOverlayDocument(getModalDocument());
+      if (!props.open || !isModalTopmost()) {
         return;
       }
       captureTriggerElement();
       focusDialog();
     });
     vue.onBeforeUnmount(() => {
-      document.removeEventListener("keydown", handleEnteringKeydown);
-      unregisterOpenModal(modalStackId);
+      unregisterModalOverlay();
     });
     const handleTrapTab = (event) => {
-      if (!props.open || !shouldTrapFocus.value || event.key !== "Tab") {
+      if (!props.open || !isModalTopmost() || !shouldTrapFocus.value || event.key !== "Tab") {
         return;
       }
       const dialog = dialogRef.value;
@@ -396,7 +436,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       const focusableElements = getFocusableElements();
       const firstElement = focusableElements[0] ?? dialog;
       const lastElement = focusableElements[focusableElements.length - 1] ?? dialog;
-      const activeElement = document.activeElement;
+      const activeElement = dialog.ownerDocument.activeElement;
       if (event.shiftKey) {
         if (activeElement === firstElement || !dialog.contains(activeElement)) {
           event.preventDefault();
@@ -436,17 +476,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         close();
       }
     };
-    const handleEnteringKeydown = (event) => {
-      if (!props.open || !props.keyboard || event.key !== "Escape" || motion.phase.value !== "enter" || document.activeElement !== triggerElement.value || !isTopmostOpenModal(modalStackId)) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      close();
-    };
     const handleKeydown = (event) => {
       handleTrapTab(event);
-      if (props.keyboard && event.key === "Escape" && isTopmostOpenModal(modalStackId)) {
+      const ownerDocument = overlayDocument ?? getModalDocument();
+      if (!event.composedPath().includes(ownerDocument) && props.open && props.keyboard && event.key === "Escape" && isModalTopmost()) {
         event.preventDefault();
         event.stopPropagation();
         close();

--- a/packages/components/lib/popconfirm/popconfirm.vue.js
+++ b/packages/components/lib/popconfirm/popconfirm.vue.js
@@ -8,9 +8,13 @@ const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
+const useStableId = require("../utils/use-stable-id.js");
+const useTriggerAria = require("../utils/use-trigger-aria.js");
 const types = require("./types.js");
 require("./style.css.js");
-const _hoisted_1 = ["aria-hidden"];
+const _hoisted_1 = ["aria-controls", "aria-expanded"];
+const _hoisted_2 = ["id", "aria-labelledby", "aria-hidden"];
+const _hoisted_3 = ["id"];
 const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   ...{
     name: "APopconfirm"
@@ -39,6 +43,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const rootRef = vue.ref(null);
     const triggerRef = vue.ref(null);
     const popupRef = vue.ref(null);
+    const popupId = useStableId.useStableId(void 0, "aheart-popconfirm");
+    const titleId = useStableId.useStableId(void 0, "aheart-popconfirm-title");
     const arrowRef = vue.ref(null);
     const effectivePlacement = vue.ref(props.placement);
     const isControlled = vue.computed(() => props.open !== void 0);
@@ -75,6 +81,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const resolvedIcon = vue.computed(() => props.icon === void 0 ? "!" : props.icon);
     const hasIcon = vue.computed(() => Boolean(slots.icon) || hasRenderable(resolvedIcon.value));
     const hasTitle = vue.computed(() => Boolean(slots.title) || hasRenderable(props.title));
+    useTriggerAria.useTriggerAria(triggerRef, () => ({
+      "aria-controls": popupId.value,
+      "aria-expanded": mergedOpen.value ? "true" : "false"
+    }));
     const hasDescription = vue.computed(() => Boolean(slots.description) || hasRenderable(props.description));
     const semanticInfo = vue.computed(() => ({
       open: visible.value,
@@ -239,21 +249,30 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     const handleFocusIn = () => {
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
         requestOpen(true);
       }
     };
-    const handleFocusOut = () => {
+    const handleFocusOut = (event) => {
+      var _a, _b;
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && (((_a = rootRef.value) == null ? void 0 : _a.contains(nextTarget)) || ((_b = popupRef.value) == null ? void 0 : _b.contains(nextTarget)))) {
+          return;
+        }
         requestOpen(false);
       }
     };
     const handleClick = () => {
       if (normalizedTriggers.value.has("click")) {
+        clearHoverTimers();
         requestOpen(!mergedOpen.value);
       }
     };
     const handleContextmenu = (event) => {
       if (normalizedTriggers.value.has("contextMenu")) {
+        clearHoverTimers();
         event.preventDefault();
         requestOpen(true);
       }
@@ -291,6 +310,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           ref_key: "triggerRef",
           ref: triggerRef,
           class: vue.normalizeClass(["aheart-popconfirm__trigger", triggerClass.value]),
+          "aria-controls": vue.unref(popupId),
+          "aria-expanded": mergedOpen.value ? "true" : "false",
           style: vue.normalizeStyle(triggerStyle.value),
           onMouseenter: handleMouseEnter,
           onMouseleave: handleMouseLeave,
@@ -300,7 +321,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           onContextmenu: handleContextmenu
         }, [
           vue.renderSlot(_ctx.$slots, "default")
-        ], 38),
+        ], 46, _hoisted_1),
         (vue.openBlock(), vue.createBlock(vue.Teleport, {
           to: teleportTo.value,
           disabled: !shouldTeleport.value
@@ -310,11 +331,14 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             ref_key: "popupRef",
             ref: popupRef,
             class: vue.normalizeClass(["aheart-popconfirm__popup", popupClass.value]),
+            id: vue.unref(popupId),
             style: vue.normalizeStyle(popupStyle.value),
             role: "dialog",
+            "aria-labelledby": hasTitle.value ? vue.unref(titleId) : void 0,
             "aria-hidden": vue.unref(motion).phase.value === "hidden" ? "true" : void 0,
             onMouseenter: handleMouseEnter,
             onMouseleave: handleMouseLeave,
+            onFocusout: handleFocusOut,
             onClick: handlePopupClick
           }, [
             showArrow.value ? (vue.openBlock(), vue.createElementBlock("span", {
@@ -349,13 +373,14 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                 }, [
                   hasTitle.value ? (vue.openBlock(), vue.createElementBlock("span", {
                     key: 0,
+                    id: vue.unref(titleId),
                     class: vue.normalizeClass(["aheart-popconfirm__title", titleClass.value]),
                     style: vue.normalizeStyle(titleStyle.value)
                   }, [
                     vue.renderSlot(_ctx.$slots, "title", {}, () => [
                       vue.createVNode(vue.unref(ARenderNode), { node: _ctx.title }, null, 8, ["node"])
                     ])
-                  ], 6)) : vue.createCommentVNode("", true),
+                  ], 14, _hoisted_3)) : vue.createCommentVNode("", true),
                   hasDescription.value ? (vue.openBlock(), vue.createElementBlock("span", {
                     key: 1,
                     class: vue.normalizeClass(["aheart-popconfirm__description", descriptionClass.value]),
@@ -393,7 +418,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                 }, 16, ["class", "style"])
               ], 6)
             ], 6)
-          ], 46, _hoisted_1)), [
+          ], 46, _hoisted_2)), [
             [vue.vShow, vue.unref(motion).phase.value !== "hidden"]
           ]) : vue.createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/lib/popover/popover.vue.js
+++ b/packages/components/lib/popover/popover.vue.js
@@ -7,9 +7,13 @@ const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
+const useStableId = require("../utils/use-stable-id.js");
+const useTriggerAria = require("../utils/use-trigger-aria.js");
 const types = require("./types.js");
 require("./style.css.js");
-const _hoisted_1 = ["aria-hidden"];
+const _hoisted_1 = ["aria-controls", "aria-expanded"];
+const _hoisted_2 = ["id", "aria-labelledby", "aria-hidden"];
+const _hoisted_3 = ["id"];
 const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   ...{
     name: "APopover"
@@ -38,6 +42,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const rootRef = vue.ref(null);
     const triggerRef = vue.ref(null);
     const popupRef = vue.ref(null);
+    const popupId = useStableId.useStableId(void 0, "aheart-popover");
+    const titleId = useStableId.useStableId(void 0, "aheart-popover-title");
     const arrowRef = vue.ref(null);
     const effectivePlacement = vue.ref(props.placement);
     let mouseEnterTimer;
@@ -46,6 +52,10 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const mergedOpen = vue.computed(() => props.open ?? innerOpen.value);
     const normalizedTriggers = vue.computed(() => new Set(floatingCore.normalizeFloatingTriggers(props.trigger)));
     const hasTitle = vue.computed(() => Boolean(slots.title) || hasRenderable(props.title));
+    useTriggerAria.useTriggerAria(triggerRef, () => ({
+      "aria-controls": popupId.value,
+      "aria-expanded": mergedOpen.value ? "true" : "false"
+    }));
     const hasContent = vue.computed(() => Boolean(slots.content) || hasRenderable(props.content));
     const hasPopupContent = vue.computed(() => hasTitle.value || hasContent.value);
     const visible = vue.computed(() => hasPopupContent.value && mergedOpen.value);
@@ -204,21 +214,30 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     const handleFocusIn = () => {
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
         requestOpen(true);
       }
     };
-    const handleFocusOut = () => {
+    const handleFocusOut = (event) => {
+      var _a, _b;
       if (normalizedTriggers.value.has("focus")) {
+        clearHoverTimers();
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && (((_a = rootRef.value) == null ? void 0 : _a.contains(nextTarget)) || ((_b = popupRef.value) == null ? void 0 : _b.contains(nextTarget)))) {
+          return;
+        }
         requestOpen(false);
       }
     };
     const handleClick = () => {
       if (normalizedTriggers.value.has("click")) {
+        clearHoverTimers();
         requestOpen(!mergedOpen.value);
       }
     };
     const handleContextmenu = (event) => {
       if (normalizedTriggers.value.has("contextMenu")) {
+        clearHoverTimers();
         event.preventDefault();
         requestOpen(true);
       }
@@ -245,6 +264,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           ref_key: "triggerRef",
           ref: triggerRef,
           class: vue.normalizeClass(["aheart-popover__trigger", triggerClass.value]),
+          "aria-controls": vue.unref(popupId),
+          "aria-expanded": mergedOpen.value ? "true" : "false",
           style: vue.normalizeStyle(triggerStyle.value),
           onMouseenter: handleMouseEnter,
           onMouseleave: handleMouseLeave,
@@ -254,7 +275,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           onContextmenu: handleContextmenu
         }, [
           vue.renderSlot(_ctx.$slots, "default")
-        ], 38),
+        ], 46, _hoisted_1),
         (vue.openBlock(), vue.createBlock(vue.Teleport, {
           to: teleportTo.value,
           disabled: !shouldTeleport.value
@@ -264,11 +285,14 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             ref_key: "popupRef",
             ref: popupRef,
             class: vue.normalizeClass(["aheart-popover__popup", popupClass.value]),
+            id: vue.unref(popupId),
             style: vue.normalizeStyle(popupStyle.value),
             role: "dialog",
+            "aria-labelledby": hasTitle.value ? vue.unref(titleId) : void 0,
             "aria-hidden": vue.unref(motion).phase.value === "hidden" ? "true" : void 0,
             onMouseenter: handleMouseEnter,
-            onMouseleave: handleMouseLeave
+            onMouseleave: handleMouseLeave,
+            onFocusout: handleFocusOut
           }, [
             showArrow.value ? (vue.openBlock(), vue.createElementBlock("span", {
               key: 0,
@@ -284,13 +308,14 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             }, [
               hasTitle.value ? (vue.openBlock(), vue.createElementBlock("span", {
                 key: 0,
+                id: vue.unref(titleId),
                 class: vue.normalizeClass(["aheart-popover__title", titleClass.value]),
                 style: vue.normalizeStyle(titleStyle.value)
               }, [
                 vue.renderSlot(_ctx.$slots, "title", {}, () => [
                   vue.createVNode(vue.unref(ARenderNode), { node: _ctx.title }, null, 8, ["node"])
                 ])
-              ], 6)) : vue.createCommentVNode("", true),
+              ], 14, _hoisted_3)) : vue.createCommentVNode("", true),
               hasContent.value ? (vue.openBlock(), vue.createElementBlock("span", {
                 key: 1,
                 class: vue.normalizeClass(["aheart-popover__content", contentClass.value]),
@@ -301,7 +326,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                 ])
               ], 6)) : vue.createCommentVNode("", true)
             ], 6)
-          ], 46, _hoisted_1)), [
+          ], 46, _hoisted_2)), [
             [vue.vShow, vue.unref(motion).phase.value !== "hidden"]
           ]) : vue.createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/lib/tooltip/tooltip.vue.js
+++ b/packages/components/lib/tooltip/tooltip.vue.js
@@ -7,9 +7,12 @@ const useFloatingDismiss = require("../utils/use-floating-dismiss.js");
 const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
+const useStableId = require("../utils/use-stable-id.js");
+const useTriggerAria = require("../utils/use-trigger-aria.js");
 const types = require("./types.js");
 require("./style.css.js");
-const _hoisted_1 = ["aria-hidden"];
+const _hoisted_1 = ["aria-describedby"];
+const _hoisted_2 = ["id", "aria-hidden"];
 const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   ...{
     name: "ATooltip"
@@ -38,12 +41,16 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const rootRef = vue.ref(null);
     const triggerRef = vue.ref(null);
     const popupRef = vue.ref(null);
+    const popupId = useStableId.useStableId(void 0, "aheart-tooltip");
     const arrowRef = vue.ref(null);
     const effectivePlacement = vue.ref(props.placement);
     const isControlled = vue.computed(() => props.open !== void 0);
     const mergedOpen = vue.computed(() => props.open ?? innerOpen.value);
     const normalizedTriggers = vue.computed(() => new Set(floatingCore.normalizeFloatingTriggers(props.trigger)));
     const hasTitle = vue.computed(() => Boolean(slots.title) || hasTitleContent(props.title));
+    useTriggerAria.useTriggerAria(triggerRef, () => ({
+      "aria-describedby": hasTitle.value ? popupId.value : void 0
+    }));
     const visible = vue.computed(() => hasTitle.value && mergedOpen.value);
     const shouldDestroyOnHidden = vue.computed(() => props.destroyOnHidden || props.destroyTooltipOnHide);
     const motion = useMotionPresence.useMotionPresence(visible, { destroyOnHidden: shouldDestroyOnHidden, duration: 120 });
@@ -182,21 +189,30 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     };
     const handleFocusIn = () => {
       if (normalizedTriggers.value.has("focus")) {
+        clearTimers();
         requestOpen(true);
       }
     };
-    const handleFocusOut = () => {
+    const handleFocusOut = (event) => {
+      var _a, _b;
       if (normalizedTriggers.value.has("focus")) {
+        clearTimers();
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && (((_a = rootRef.value) == null ? void 0 : _a.contains(nextTarget)) || ((_b = popupRef.value) == null ? void 0 : _b.contains(nextTarget)))) {
+          return;
+        }
         requestOpen(false);
       }
     };
     const handleClick = () => {
       if (normalizedTriggers.value.has("click")) {
+        clearTimers();
         requestOpen(!mergedOpen.value);
       }
     };
     const handleContextmenu = (event) => {
       if (normalizedTriggers.value.has("contextMenu")) {
+        clearTimers();
         event.preventDefault();
         requestOpen(true);
       }
@@ -221,6 +237,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           ref_key: "triggerRef",
           ref: triggerRef,
           class: vue.normalizeClass(["aheart-tooltip__trigger", triggerClass.value]),
+          "aria-describedby": hasTitle.value ? vue.unref(popupId) : void 0,
           style: vue.normalizeStyle(triggerStyle.value),
           onMouseenter: handleMouseEnter,
           onMouseleave: handleMouseLeave,
@@ -230,7 +247,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           onContextmenu: handleContextmenu
         }, [
           vue.renderSlot(_ctx.$slots, "default")
-        ], 38),
+        ], 46, _hoisted_1),
         (vue.openBlock(), vue.createBlock(vue.Teleport, {
           to: teleportTo.value,
           disabled: !shouldTeleport.value
@@ -240,11 +257,13 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             ref_key: "popupRef",
             ref: popupRef,
             class: vue.normalizeClass(["aheart-tooltip__popup", popupClass.value]),
+            id: vue.unref(popupId),
             style: vue.normalizeStyle(popupStyle.value),
             role: "tooltip",
             "aria-hidden": vue.unref(motion).phase.value === "hidden" ? "true" : void 0,
             onMouseenter: handleMouseEnter,
-            onMouseleave: handleMouseLeave
+            onMouseleave: handleMouseLeave,
+            onFocusout: handleFocusOut
           }, [
             showArrow.value ? (vue.openBlock(), vue.createElementBlock("span", {
               key: 0,
@@ -267,7 +286,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
                 ])
               ], 6)
             ], 6)
-          ], 46, _hoisted_1)), [
+          ], 46, _hoisted_2)), [
             [vue.vShow, vue.unref(motion).phase.value !== "hidden"]
           ]) : vue.createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/lib/tree-select/tree-select.vue.js
+++ b/packages/components/lib/tree-select/tree-select.vue.js
@@ -8,9 +8,10 @@ const useFloatingPosition = require("../utils/use-floating-position.js");
 const useMotionPresence = require("../utils/use-motion-presence.js");
 const usePropPresence = require("../utils/use-prop-presence.js");
 const useControllableState = require("../utils/use-controllable-state.js");
+const useStableId = require("../utils/use-stable-id.js");
 const useTeleportReady = require("../utils/use-teleport-ready.js");
 require("./style.css.js");
-const _hoisted_1 = ["id", "tabindex", "aria-expanded", "aria-disabled", "aria-labelledby"];
+const _hoisted_1 = ["id", "tabindex", "aria-expanded", "aria-disabled", "aria-labelledby", "aria-activedescendant", "aria-describedby"];
 const _hoisted_2 = {
   key: 0,
   class: "aheart-tree-select__value aheart-tree-select__tags"
@@ -21,7 +22,8 @@ const _hoisted_5 = {
   key: 0,
   class: "aheart-tree-select__tag aheart-tree-select__tag--rest"
 };
-const _hoisted_6 = {
+const _hoisted_6 = ["aria-labelledby", "aria-describedby", "aria-label"];
+const _hoisted_7 = {
   key: 1,
   class: "aheart-tree-select__empty",
   role: "status"
@@ -52,6 +54,9 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
   setup(__props, { emit: __emit }) {
     const props = __props;
     const attrs = vue.useAttrs();
+    const instanceId = useStableId.useStableId(void 0, "aheart-tree-select").value;
+    const panelId = `aheart-tree-select-panel-${instanceId}`;
+    const treeId = `aheart-tree-select-tree-${instanceId}`;
     const emit = __emit;
     const rootRef = vue.ref(null);
     const triggerRef = vue.ref(null);
@@ -60,6 +65,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
     const isControlled = usePropPresence.usePropPresence("modelValue", "model-value");
     const isOpenControlled = usePropPresence.usePropPresence("open");
     const resolvedAriaLabelledby = vue.computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs["aria-labelledby"]);
+    const resolvedAriaDescribedby = vue.computed(() => attrs["aria-describedby"]);
     const openState = useControllableState.useControllableState({
       controlled: () => props.open,
       isControlled: isOpenControlled,
@@ -105,6 +111,34 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
       const query = searchText.value.trim().toLowerCase();
       return query ? filterNodes(props.treeData, query) : props.treeData;
     });
+    const activeKey = vue.ref();
+    const nodeId = (key) => `${instanceId}-node-${encodeURIComponent(String(key)).replaceAll("%", "_")}`;
+    const activeNodeId = vue.computed(() => {
+      if (!mergedOpen.value || activeKey.value === void 0)
+        return void 0;
+      return flattenNodes(filteredTreeData.value).some((node) => String(node.key) === String(activeKey.value)) ? nodeId(activeKey.value) : void 0;
+    });
+    const syncTreeNodeIds = () => {
+      var _a;
+      for (const element of Array.from(((_a = panelRef.value) == null ? void 0 : _a.querySelectorAll("[data-tree-key]")) ?? [])) {
+        const key = element.dataset.treeKey;
+        if (key !== void 0)
+          element.id = nodeId(key);
+      }
+    };
+    vue.watch([filteredTreeData, mergedOpen], ([, open]) => {
+      if (open)
+        void vue.nextTick(syncTreeNodeIds);
+    }, { flush: "post" });
+    const handleTreeFocusin = (event) => {
+      var _a;
+      const node = event.target.closest("[data-tree-key]");
+      if ((node == null ? void 0 : node.dataset.treeKey) !== void 0) {
+        const key = node.dataset.treeKey;
+        activeKey.value = ((_a = flattenNodes(filteredTreeData.value).find((item) => String(item.key) === key)) == null ? void 0 : _a.key) ?? key;
+        syncTreeNodeIds();
+      }
+    };
     const searchExpandedKeys = vue.computed(() => flattenNodes(filteredTreeData.value).filter((node) => {
       var _a;
       return (_a = node.children) == null ? void 0 : _a.length;
@@ -141,8 +175,12 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
         event.preventDefault();
         requestOpen(true);
         void vue.nextTick(() => {
-          var _a, _b;
-          return (_b = (_a = panelRef.value) == null ? void 0 : _a.querySelector('[data-tree-key][tabindex="0"]')) == null ? void 0 : _b.focus();
+          var _a;
+          syncTreeNodeIds();
+          const node = (_a = panelRef.value) == null ? void 0 : _a.querySelector('[data-tree-key][tabindex="0"]');
+          if ((node == null ? void 0 : node.dataset.treeKey) !== void 0)
+            activeKey.value = node.dataset.treeKey;
+          node == null ? void 0 : node.focus();
         });
       } else if (event.key === "Escape" && mergedOpen.value) {
         event.preventDefault();
@@ -204,6 +242,9 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
           "aria-expanded": mergedOpen.value ? "true" : "false",
           "aria-disabled": __props.disabled ? "true" : void 0,
           "aria-labelledby": resolvedAriaLabelledby.value,
+          "aria-controls": panelId,
+          "aria-activedescendant": activeNodeId.value,
+          "aria-describedby": resolvedAriaDescribedby.value,
           "aria-haspopup": "tree",
           onClick: toggleOpen,
           onKeydown: handleTriggerKeydown
@@ -262,7 +303,13 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
             ref_key: "panelRef",
             ref: panelRef,
             class: vue.normalizeClass(["aheart-tree-select__panel", panelClass.value]),
-            style: vue.normalizeStyle(panelStyle.value)
+            style: vue.normalizeStyle(panelStyle.value),
+            id: panelId,
+            role: "dialog",
+            "aria-labelledby": resolvedAriaLabelledby.value || void 0,
+            "aria-describedby": resolvedAriaDescribedby.value || void 0,
+            "aria-label": resolvedAriaLabelledby.value ? void 0 : "树选择",
+            onFocusin: handleTreeFocusin
           }, [
             __props.showSearch ? vue.withDirectives((vue.openBlock(), vue.createElementBlock("input", {
               key: 0,
@@ -275,6 +322,7 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
               [vue.vModelText, searchText.value]
             ]) : vue.createCommentVNode("", true),
             vue.createVNode(vue.unref(index.default), {
+              id: treeId,
               "tree-data": filteredTreeData.value,
               "selected-keys": selectedKeys.value,
               "expanded-keys": searchText.value ? searchExpandedKeys.value : void 0,
@@ -282,8 +330,8 @@ const _sfc_main = /* @__PURE__ */ vue.defineComponent({
               disabled: __props.disabled,
               "onUpdate:selectedKeys": handleSelect
             }, null, 8, ["tree-data", "selected-keys", "expanded-keys", "multiple", "disabled"]),
-            searchText.value.trim() && filteredTreeData.value.length === 0 ? (vue.openBlock(), vue.createElementBlock("div", _hoisted_6, "暂无匹配节点")) : vue.createCommentVNode("", true)
-          ], 6)), [
+            searchText.value.trim() && filteredTreeData.value.length === 0 ? (vue.openBlock(), vue.createElementBlock("div", _hoisted_7, "暂无匹配节点")) : vue.createCommentVNode("", true)
+          ], 46, _hoisted_6)), [
             [vue.vShow, vue.unref(motion).phase.value !== "hidden"]
           ]) : vue.createCommentVNode("", true)
         ], 8, ["to", "disabled"]))

--- a/packages/components/lib/utils/overlay-controller.d.ts
+++ b/packages/components/lib/utils/overlay-controller.d.ts
@@ -1,0 +1,23 @@
+export interface OverlayRegistration {
+    id: symbol;
+    document?: Document;
+    getTrigger?: () => Element | null | undefined;
+    getContent?: () => Element | null | undefined;
+    escapeEnabled?: boolean | (() => boolean);
+    getBaseZIndex?: () => number;
+    onZIndexChange?: (zIndex: number) => void;
+    onEscape?: (event: KeyboardEvent) => void;
+    onPointerDownOutside?: (event: PointerEvent) => void;
+}
+export declare const getRecentPointerTarget: (ownerDocument?: Document, maxAge?: number) => Element | null;
+export declare const refreshOverlayStack: (ownerDocument?: Document) => void;
+/** True when target is in this overlay or in an overlay opened from its content. */
+export declare const isTargetInOverlayTree: (id: symbol, target: EventTarget | null | readonly EventTarget[], ownerDocument?: Document) => boolean;
+/** Installs the lightweight input tracker before a closed blocking overlay is opened. */
+export declare const prepareOverlayDocument: (ownerDocument?: Document) => void;
+export declare const registerOverlay: (registration: OverlayRegistration) => () => void;
+export declare const updateOverlay: (id: symbol, patch: Partial<Omit<OverlayRegistration, 'id' | 'document'>>, ownerDocument?: Document) => void;
+export declare const unregisterOverlay: (id: symbol, ownerDocument?: Document) => void;
+export declare const isTopmost: (id: symbol, ownerDocument?: Document) => boolean;
+export declare const lockBodyScroll: (ownerDocument?: Document) => void;
+export declare const unlockBodyScroll: (ownerDocument?: Document) => void;

--- a/packages/components/lib/utils/overlay-controller.js
+++ b/packages/components/lib/utils/overlay-controller.js
@@ -1,0 +1,193 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const records = /* @__PURE__ */ new WeakMap();
+const listeners = /* @__PURE__ */ new WeakMap();
+const locks = /* @__PURE__ */ new WeakMap();
+const recentPointerTargets = /* @__PURE__ */ new WeakMap();
+const INTERACTIVE_SELECTOR = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])'
+].join(",");
+const getRecords = (ownerDocument) => {
+  let value = records.get(ownerDocument);
+  if (!value) {
+    value = [];
+    records.set(ownerDocument, value);
+  }
+  return value;
+};
+const isEscapeEnabled = (record) => typeof record.escapeEnabled === "function" ? record.escapeEnabled() : record.escapeEnabled !== false;
+const getElement = (getter) => (getter == null ? void 0 : getter()) ?? null;
+const getRecentPointerTarget = (ownerDocument = document, maxAge = 500) => {
+  const recent = recentPointerTargets.get(ownerDocument);
+  return recent && Date.now() - recent.recordedAt <= maxAge ? recent.target : null;
+};
+const refreshOverlayStack = (ownerDocument = document) => {
+  var _a;
+  let previousZIndex = Number.NEGATIVE_INFINITY;
+  for (const record of getRecords(ownerDocument)) {
+    if (!record.onZIndexChange)
+      continue;
+    const baseZIndex = ((_a = record.getBaseZIndex) == null ? void 0 : _a.call(record)) ?? 0;
+    const zIndex = Number.isFinite(previousZIndex) ? Math.max(baseZIndex, previousZIndex + 10) : baseZIndex;
+    record.onZIndexChange(zIndex);
+    previousZIndex = zIndex;
+  }
+};
+const containsTarget = (record, targets) => {
+  var _a;
+  const NodeConstructor = (_a = record.document.defaultView) == null ? void 0 : _a.Node;
+  return targets.some(
+    (target) => Boolean(
+      NodeConstructor && target instanceof NodeConstructor && [getElement(record.getTrigger), getElement(record.getContent)].some((element) => element == null ? void 0 : element.contains(target))
+    )
+  );
+};
+const isTargetInOverlayTree = (id, target, ownerDocument = document) => {
+  const stack = getRecords(ownerDocument);
+  const record = stack.find((entry) => entry.id === id);
+  if (!record)
+    return false;
+  const targets = Array.isArray(target) ? target : [target];
+  if (containsTarget(record, targets))
+    return true;
+  const getParent = (child) => {
+    const childIndex = stack.indexOf(child);
+    const childTrigger = getElement(child.getTrigger);
+    const childContent = getElement(child.getContent);
+    for (let index = childIndex - 1; index >= 0; index -= 1) {
+      const candidate = stack[index];
+      const candidateContent = getElement(candidate.getContent);
+      if (candidateContent && (candidateContent.contains(childTrigger) || candidateContent.contains(childContent))) {
+        return candidate;
+      }
+    }
+  };
+  return stack.some((candidate) => {
+    if (candidate.id === id || !containsTarget(candidate, targets))
+      return false;
+    const visited = /* @__PURE__ */ new Set();
+    let parent = getParent(candidate);
+    while (parent && !visited.has(parent.id)) {
+      if (parent.id === id)
+        return true;
+      visited.add(parent.id);
+      parent = getParent(parent);
+    }
+    return false;
+  });
+};
+const ensureListeners = (ownerDocument) => {
+  if (listeners.has(ownerDocument))
+    return;
+  const keydown = (event) => {
+    var _a;
+    recentPointerTargets.delete(ownerDocument);
+    if (event.key !== "Escape")
+      return;
+    const stack = getRecords(ownerDocument);
+    const top = stack[stack.length - 1];
+    if (!top)
+      return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (isEscapeEnabled(top))
+      (_a = top.onEscape) == null ? void 0 : _a.call(top, event);
+  };
+  const pointerdown = (event) => {
+    var _a, _b, _c;
+    const ElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.Element;
+    const pathTarget = (((_b = event.composedPath) == null ? void 0 : _b.call(event)) ?? [event.target]).find(
+      (target) => ElementConstructor && target instanceof ElementConstructor
+    );
+    const pathElement = ElementConstructor && pathTarget instanceof ElementConstructor ? pathTarget : null;
+    const pointerTarget = (pathElement == null ? void 0 : pathElement.closest(INTERACTIVE_SELECTOR)) ?? pathElement;
+    if (pointerTarget)
+      recentPointerTargets.set(ownerDocument, { target: pointerTarget, recordedAt: Date.now() });
+    const stack = getRecords(ownerDocument);
+    const top = stack[stack.length - 1];
+    const path = ((_c = event.composedPath) == null ? void 0 : _c.call(event)) ?? [event.target];
+    if (!top || !top.onPointerDownOutside || isTargetInOverlayTree(top.id, path, ownerDocument))
+      return;
+    top.onPointerDownOutside(event);
+  };
+  ownerDocument.addEventListener("keydown", keydown, true);
+  ownerDocument.addEventListener("pointerdown", pointerdown, true);
+  listeners.set(ownerDocument, { keydown, pointerdown });
+};
+const prepareOverlayDocument = (ownerDocument = document) => {
+  ensureListeners(ownerDocument);
+};
+const registerOverlay = (registration) => {
+  const ownerDocument = registration.document ?? document;
+  const stack = getRecords(ownerDocument);
+  const existing = stack.findIndex((entry) => entry.id === registration.id);
+  if (existing >= 0)
+    stack.splice(existing, 1);
+  stack.push({ ...registration, document: ownerDocument });
+  refreshOverlayStack(ownerDocument);
+  ensureListeners(ownerDocument);
+  return () => unregisterOverlay(registration.id, ownerDocument);
+};
+const unregisterOverlay = (id, ownerDocument = document) => {
+  const stack = getRecords(ownerDocument);
+  const index = stack.findIndex((entry) => entry.id === id);
+  if (index >= 0)
+    stack.splice(index, 1);
+  refreshOverlayStack(ownerDocument);
+  if (stack.length === 0) {
+    records.delete(ownerDocument);
+  }
+};
+const isTopmost = (id, ownerDocument = document) => {
+  var _a;
+  const stack = getRecords(ownerDocument);
+  return ((_a = stack[stack.length - 1]) == null ? void 0 : _a.id) === id;
+};
+const lockBodyScroll = (ownerDocument = document) => {
+  var _a, _b;
+  const body = ownerDocument.body;
+  if (!body)
+    return;
+  const state = locks.get(ownerDocument);
+  if (state) {
+    state.count += 1;
+    return;
+  }
+  const paddingRight = body.style.paddingRight;
+  const viewportWidth = ((_a = ownerDocument.defaultView) == null ? void 0 : _a.innerWidth) ?? 0;
+  const contentWidth = ownerDocument.documentElement.clientWidth;
+  const scrollbarWidth = contentWidth > 0 ? Math.max(0, viewportWidth - contentWidth) : 0;
+  locks.set(ownerDocument, { count: 1, overflow: body.style.overflow, paddingRight });
+  if (scrollbarWidth > 0) {
+    const currentPadding = Number.parseFloat(((_b = ownerDocument.defaultView) == null ? void 0 : _b.getComputedStyle(body).paddingRight) ?? "0") || 0;
+    body.style.paddingRight = `${currentPadding + scrollbarWidth}px`;
+  }
+  body.style.overflow = "hidden";
+};
+const unlockBodyScroll = (ownerDocument = document) => {
+  const state = locks.get(ownerDocument);
+  if (!state)
+    return;
+  state.count -= 1;
+  if (state.count > 0)
+    return;
+  if (ownerDocument.body) {
+    ownerDocument.body.style.overflow = state.overflow;
+    ownerDocument.body.style.paddingRight = state.paddingRight;
+  }
+  locks.delete(ownerDocument);
+};
+exports.getRecentPointerTarget = getRecentPointerTarget;
+exports.isTargetInOverlayTree = isTargetInOverlayTree;
+exports.isTopmost = isTopmost;
+exports.lockBodyScroll = lockBodyScroll;
+exports.prepareOverlayDocument = prepareOverlayDocument;
+exports.refreshOverlayStack = refreshOverlayStack;
+exports.registerOverlay = registerOverlay;
+exports.unlockBodyScroll = unlockBodyScroll;
+exports.unregisterOverlay = unregisterOverlay;

--- a/packages/components/lib/utils/use-floating-dismiss.js
+++ b/packages/components/lib/utils/use-floating-dismiss.js
@@ -1,11 +1,16 @@
 "use strict";
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 const vue = require("vue");
+const overlayController = require("./overlay-controller.js");
 function useFloatingDismiss(options) {
-  let removeListeners;
+  const overlayId = Symbol("aheart-floating-overlay");
+  let unregister;
+  let restoreZIndex;
   const cleanup = () => {
-    removeListeners == null ? void 0 : removeListeners();
-    removeListeners = void 0;
+    unregister == null ? void 0 : unregister();
+    unregister = void 0;
+    restoreZIndex == null ? void 0 : restoreZIndex();
+    restoreZIndex = void 0;
   };
   const focusTrigger = () => {
     const trigger = vue.toValue(options.trigger);
@@ -23,38 +28,51 @@ function useFloatingDismiss(options) {
     target == null ? void 0 : target.focus();
   };
   vue.watchEffect((onCleanup) => {
+    var _a, _b;
     cleanup();
     if (typeof document === "undefined" || !vue.toValue(options.open)) {
       return;
     }
-    const handlePointerDown = (event) => {
-      const trigger = vue.toValue(options.trigger);
-      const floating = vue.toValue(options.floating);
-      const path = event.composedPath();
-      if (trigger && path.includes(trigger) || floating && path.includes(floating)) {
-        return;
+    const trigger = vue.toValue(options.trigger);
+    const floating = vue.toValue(options.floating);
+    const ownerDocument = (trigger == null ? void 0 : trigger.ownerDocument) ?? (floating == null ? void 0 : floating.ownerDocument) ?? document;
+    const HTMLElementConstructor = (_a = ownerDocument.defaultView) == null ? void 0 : _a.HTMLElement;
+    const floatingElement = HTMLElementConstructor && floating instanceof HTMLElementConstructor ? floating : null;
+    const originalZIndex = (floatingElement == null ? void 0 : floatingElement.style.zIndex) ?? "";
+    const computedZIndex = Number.parseFloat(
+      floatingElement ? ((_b = ownerDocument.defaultView) == null ? void 0 : _b.getComputedStyle(floatingElement).zIndex) ?? "" : ""
+    );
+    const baseZIndex = Number.isFinite(computedZIndex) ? computedZIndex : 0;
+    restoreZIndex = floatingElement ? () => {
+      floatingElement.style.zIndex = originalZIndex;
+    } : void 0;
+    unregister = overlayController.registerOverlay({
+      id: overlayId,
+      document: ownerDocument,
+      getTrigger: () => vue.toValue(options.trigger),
+      getContent: () => vue.toValue(options.floating),
+      escapeEnabled: () => vue.toValue(options.open),
+      getBaseZIndex: () => baseZIndex,
+      onZIndexChange: (zIndex) => {
+        const content = vue.toValue(options.floating);
+        if (HTMLElementConstructor && content instanceof HTMLElementConstructor) {
+          content.style.zIndex = String(zIndex);
+        }
+      },
+      onPointerDownOutside: (event) => {
+        if (vue.toValue(options.open))
+          options.onDismiss("outside", event);
+      },
+      onEscape: (event) => {
+        options.onDismiss("escape", event);
+        if (vue.toValue(options.restoreFocus) !== false) {
+          void vue.nextTick(() => {
+            if (!vue.toValue(options.open))
+              focusTrigger();
+          });
+        }
       }
-      options.onDismiss("outside", event);
-    };
-    const handleKeydown = (event) => {
-      if (event.key !== "Escape") {
-        return;
-      }
-      event.preventDefault();
-      options.onDismiss("escape", event);
-      if (vue.toValue(options.restoreFocus) !== false) {
-        void vue.nextTick(() => {
-          if (!vue.toValue(options.open))
-            focusTrigger();
-        });
-      }
-    };
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    document.addEventListener("keydown", handleKeydown, true);
-    removeListeners = () => {
-      document.removeEventListener("pointerdown", handlePointerDown, true);
-      document.removeEventListener("keydown", handleKeydown, true);
-    };
+    });
     onCleanup(cleanup);
   });
   vue.onScopeDispose(cleanup);

--- a/packages/components/lib/utils/use-trigger-aria.d.ts
+++ b/packages/components/lib/utils/use-trigger-aria.d.ts
@@ -1,0 +1,6 @@
+import { type MaybeRefOrGetter } from 'vue';
+type TriggerAriaValue = string | undefined;
+type TriggerAriaAttributes = Record<`aria-${string}`, TriggerAriaValue>;
+/** Mirrors wrapper-owned popup relationships onto the actual slotted focus target. */
+export declare const useTriggerAria: (rootSource: MaybeRefOrGetter<HTMLElement | null | undefined>, getAttributes: () => TriggerAriaAttributes) => void;
+export {};

--- a/packages/components/lib/utils/use-trigger-aria.js
+++ b/packages/components/lib/utils/use-trigger-aria.js
@@ -1,0 +1,64 @@
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const vue = require("vue");
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])'
+].join(",");
+const TOKEN_ATTRIBUTES = /* @__PURE__ */ new Set(["aria-describedby", "aria-labelledby"]);
+const useTriggerAria = (rootSource, getAttributes) => {
+  let sequence = 0;
+  let target = null;
+  let originals = /* @__PURE__ */ new Map();
+  const restore = () => {
+    if (!target)
+      return;
+    for (const [name, value] of originals) {
+      if (value === null)
+        target.removeAttribute(name);
+      else
+        target.setAttribute(name, value);
+    }
+    target = null;
+    originals = /* @__PURE__ */ new Map();
+  };
+  vue.watchEffect(() => {
+    const root = vue.toValue(rootSource);
+    const attributes = getAttributes();
+    const currentSequence = ++sequence;
+    void vue.nextTick(() => {
+      if (currentSequence !== sequence)
+        return;
+      const nextTarget = (root == null ? void 0 : root.matches(FOCUSABLE_SELECTOR)) ? root : (root == null ? void 0 : root.querySelector(FOCUSABLE_SELECTOR)) ?? null;
+      if (nextTarget !== target) {
+        restore();
+        target = nextTarget;
+      }
+      if (!target)
+        return;
+      for (const [name, value] of Object.entries(attributes)) {
+        if (!originals.has(name))
+          originals.set(name, target.getAttribute(name));
+        const original = originals.get(name);
+        if (value === void 0) {
+          if (original === null)
+            target.removeAttribute(name);
+          else if (original !== void 0)
+            target.setAttribute(name, original);
+          continue;
+        }
+        const resolvedValue = TOKEN_ATTRIBUTES.has(name) && original ? Array.from(/* @__PURE__ */ new Set([...original.split(/\s+/), value])).join(" ") : value;
+        target.setAttribute(name, resolvedValue);
+      }
+    });
+  });
+  vue.onScopeDispose(() => {
+    sequence += 1;
+    restore();
+  });
+};
+exports.useTriggerAria = useTriggerAria;

--- a/packages/components/src/cascader/__tests__/cascader.test.ts
+++ b/packages/components/src/cascader/__tests__/cascader.test.ts
@@ -1,6 +1,8 @@
-import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
 import Cascader from '../cascader.vue'
+
+enableAutoUnmount(afterEach)
 
 const mountCascader = (options: Record<string, any> = {}) => mount(Cascader, {
   ...options,
@@ -20,6 +22,40 @@ const options = [
 ]
 
 describe('Cascader', () => {
+  it('connects the combobox to its panel and visible active option', async () => {
+    const wrapper = mountCascader({ attrs: { 'aria-labelledby': 'country-label', 'aria-describedby': 'country-help' }, props: { options } })
+    const trigger = wrapper.get('.aheart-cascader__trigger')
+    await trigger.trigger('click')
+    const panel = wrapper.get('.aheart-cascader__panel')
+    expect(trigger.attributes('aria-controls')).toBe(panel.attributes('id'))
+    expect(trigger.attributes('aria-labelledby')).toBe('country-label')
+    expect(trigger.attributes('aria-describedby')).toBe('country-help')
+    const first = wrapper.get('[data-cascader-value="zhejiang"]')
+    await first.trigger('focus')
+    const activeId = trigger.attributes('aria-activedescendant')
+    expect(activeId).toBe(first.attributes('id'))
+    expect(panel.element.querySelector(`#${activeId}`)).toBe(first.element)
+  })
+
+  it('supports Home/End and left/right column navigation', async () => {
+    const wrapper = mount(Cascader, { attachTo: document.body, props: { options } })
+    const getOption = (value: string) =>
+      document.querySelector<HTMLElement>(`.aheart-cascader__option[data-cascader-value="${value}"]`)!
+    await wrapper.get('.aheart-cascader__trigger').trigger('click')
+    getOption('zhejiang').dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    await wrapper.vm.$nextTick()
+    await Promise.resolve()
+    await wrapper.vm.$nextTick()
+    const city = getOption('hangzhou')
+    expect(wrapper.get('.aheart-cascader__trigger').attributes('aria-activedescendant')).toBe(city.id)
+    city.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    const currentProvince = getOption('zhejiang')
+    expect(document.activeElement).toBe(currentProvince)
+    currentProvince.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+    expect(document.activeElement).toBe(currentProvince)
+    wrapper.unmount()
+  })
+
   it('emits a selected leaf path', async () => {
     const wrapper = mountCascader({ props: { options } })
 

--- a/packages/components/src/cascader/__tests__/overlay-controls.ssr.test.ts
+++ b/packages/components/src/cascader/__tests__/overlay-controls.ssr.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { renderToString } from '@vue/server-renderer'
+import { createSSRApp, h } from 'vue'
+import { describe, expect, it } from 'vitest'
+import Cascader from '../cascader.vue'
+import TreeSelect from '../../tree-select/tree-select.vue'
+
+const render = (component: Parameters<typeof h>[0], props: Record<string, unknown>) =>
+  renderToString(createSSRApp({ render: () => h(component, props) }))
+
+describe('selection overlay SSR ids', () => {
+  it('renders stable Cascader control and option relationships', async () => {
+    const props = {
+      defaultOpen: true,
+      options: [{ value: 'parent', label: 'Parent', children: [{ value: 'child', label: 'Child' }] }]
+    }
+    const first = await render(Cascader, props)
+    const second = await render(Cascader, props)
+    const panelId = first.match(/aria-controls="([^"]+)"/)?.[1]
+
+    expect(first).toBe(second)
+    expect(panelId).toBeTruthy()
+    expect(first).toContain(`id="${panelId}"`)
+  })
+
+  it('renders stable TreeSelect control and tree relationships', async () => {
+    const props = {
+      defaultOpen: true,
+      treeData: [{ key: 'parent', title: 'Parent', children: [{ key: 'child', title: 'Child' }] }]
+    }
+    const first = await render(TreeSelect, props)
+    const second = await render(TreeSelect, props)
+    const panelId = first.match(/aria-controls="([^"]+)"/)?.[1]
+
+    expect(first).toBe(second)
+    expect(panelId).toBeTruthy()
+    expect(first).toContain(`id="${panelId}"`)
+  })
+})

--- a/packages/components/src/cascader/cascader.vue
+++ b/packages/components/src/cascader/cascader.vue
@@ -7,6 +7,10 @@
       :tabindex="disabled ? -1 : 0"
       :aria-expanded="mergedOpen ? 'true' : 'false'"
       :aria-disabled="disabled ? 'true' : undefined"
+      :aria-controls="panelId"
+      :aria-activedescendant="activeDescendantId"
+      :aria-labelledby="resolvedAriaLabelledby"
+      :aria-describedby="resolvedAriaDescribedby"
       aria-haspopup="dialog"
       @click="toggleOpen"
       @keydown="handleTriggerKeydown"
@@ -37,7 +41,10 @@
       :class="panelClass"
       :style="panelStyle"
       role="dialog"
-      aria-label="级联选择"
+      :id="panelId"
+      :aria-labelledby="resolvedAriaLabelledby || undefined"
+      :aria-describedby="resolvedAriaDescribedby || undefined"
+      :aria-label="resolvedAriaLabelledby ? undefined : '级联选择'"
     >
       <input
         v-if="showSearch"
@@ -70,9 +77,12 @@
             :class="{ 'is-active': activePath[columnIndex] === option.value, 'is-selected': isSelected(columnIndex, option), 'is-loading': isLoading(columnIndex, option) }"
             type="button"
             :data-cascader-value="option.value"
+            :id="optionId(option, columnIndex)"
+            :data-cascader-column="columnIndex"
             :disabled="disabled || option.disabled || isLoading(columnIndex, option)"
             :aria-busy="isLoading(columnIndex, option) ? 'true' : undefined"
             @click="handleOption(option, columnIndex)"
+            @focus="handleOptionFocus(option, columnIndex)"
             @keydown="handleOptionKeydown"
           >
             <span>{{ option.label }}</span>
@@ -87,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, useAttrs, watch } from 'vue'
 import AIcon from '../icon/icon.vue'
 import type { FloatingPlacement } from '../utils/floating-core'
 import { useFloatingDismiss } from '../utils/use-floating-dismiss'
@@ -95,6 +105,7 @@ import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { usePropPresence } from '../utils/use-prop-presence'
 import { useControllableState } from '../utils/use-controllable-state'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import type { CascaderKey, CascaderOption, CascaderPath, CascaderValue } from './types'
 import './style.css'
@@ -134,12 +145,15 @@ const cloneOptions = (options: CascaderOption[]): CascaderOption[] => options.ma
   ...option,
   children: option.children ? cloneOptions(option.children) : undefined
 }))
+const instanceId = useStableId(undefined, 'aheart-cascader').value
+const panelId = `aheart-cascader-panel-${instanceId}`
 const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
 const columnsRef = ref<HTMLElement | null>(null)
 const searchText = ref('')
 const activePath = ref<CascaderPath>([])
+const focusedPath = ref<CascaderPath>([])
 const loadingPaths = ref<CascaderPath[]>([])
 const innerOptions = ref<CascaderOption[]>(cloneOptions(props.options))
 const isControlled = usePropPresence('modelValue', 'model-value')
@@ -239,6 +253,19 @@ const searchResults = computed(() => {
   const query = searchText.value.trim().toLowerCase()
   return collectLeaves(innerOptions.value).filter((result) => result.labels.join(' / ').toLowerCase().includes(query))
 })
+const attrs = useAttrs()
+const resolvedAriaLabelledby = computed(() => attrs['aria-labelledby'] as string | undefined)
+const resolvedAriaDescribedby = computed(() => attrs['aria-describedby'] as string | undefined)
+const optionId = (option: CascaderOption, columnIndex: number) =>
+  `${instanceId}-option-${columnIndex}-${Math.max(0, columns.value[columnIndex]?.indexOf(option) ?? 0)}`
+const activeDescendantId = computed(() => {
+  if (!mergedOpen.value || searchText.value.trim()) return undefined
+  const path = focusedPath.value
+  if (!path.length) return undefined
+  const option = findOption(path.slice(0, -1))?.children?.find((item) => item.value === path.at(-1)) ?? (path.length === 1 ? innerOptions.value.find((item) => item.value === path[0]) : undefined)
+  if (!option || !columns.value[path.length - 1]?.includes(option)) return undefined
+  return optionId(option, path.length - 1)
+})
 const isSelected = (columnIndex: number, option: CascaderOption) => selectedPaths.value.some((path) => path[columnIndex] === option.value && path.length === columnIndex + 1)
 const isLoading = (columnIndex: number, option: CascaderOption) => loadingPaths.value.some((path) => samePath(path, [...activePath.value.slice(0, columnIndex), option.value]))
 const requestOpen = (open: boolean) => {
@@ -304,6 +331,9 @@ const handleOption = async (option: CascaderOption, columnIndex: number) => {
     }
   }
 }
+const handleOptionFocus = (option: CascaderOption, columnIndex: number) => {
+  focusedPath.value = [...activePath.value.slice(0, columnIndex), option.value]
+}
 
 const handleTriggerKeydown = (event: KeyboardEvent) => {
   if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
@@ -320,6 +350,8 @@ const handleOptionKeydown = (event: KeyboardEvent) => {
   const current = event.currentTarget as HTMLButtonElement
   const options = Array.from(current.parentElement?.querySelectorAll<HTMLButtonElement>('.aheart-cascader__option:not(:disabled)') ?? [])
   const index = options.indexOf(current)
+  const columnIndex = Number(current.dataset.cascaderColumn)
+  const option = columns.value[columnIndex]?.find((item) => String(item.value) === current.dataset.cascaderValue)
   if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
     event.preventDefault()
     options[(index + (event.key === 'ArrowDown' ? 1 : -1) + options.length) % options.length]?.focus()
@@ -327,6 +359,17 @@ const handleOptionKeydown = (event: KeyboardEvent) => {
     event.preventDefault()
     requestOpen(false)
     void nextTick(() => triggerRef.value?.focus())
+  } else if (event.key === 'Home' || event.key === 'End') {
+    event.preventDefault()
+    options[event.key === 'Home' ? 0 : options.length - 1]?.focus()
+  } else if (event.key === 'ArrowRight' && option && isBranch(option)) {
+    event.preventDefault()
+    void handleOption(option, columnIndex).then(() => nextTick(() => panelRef.value?.querySelector<HTMLElement>(`[data-cascader-column="${columnIndex + 1}"]:not(:disabled)`)?.focus()))
+  } else if (event.key === 'ArrowLeft' && columnIndex > 0) {
+    event.preventDefault()
+    const parentValue = focusedPath.value[columnIndex - 1] ?? activePath.value[columnIndex - 1]
+    Array.from(panelRef.value?.querySelectorAll<HTMLElement>(`[data-cascader-column="${columnIndex - 1}"]`) ?? [])
+      .find((element) => element.dataset.cascaderValue === String(parentValue))?.focus()
   }
 }
 

--- a/packages/components/src/drawer/__tests__/drawer.test.ts
+++ b/packages/components/src/drawer/__tests__/drawer.test.ts
@@ -1,9 +1,11 @@
-import { mount } from '@vue/test-utils'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { h, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import Drawer from '../drawer.vue'
+
+enableAutoUnmount(afterEach)
 
 const mountDrawer = (options: Record<string, any> = {}) =>
   mount(Drawer, {
@@ -522,6 +524,37 @@ describe('Drawer', () => {
     }
   })
 
+  it('holds the body scroll lock until the leave motion is hidden', async () => {
+    const wrapper = mountDrawer({ props: { open: true, title: 'Scroll lock' } })
+    expect(document.body.style.overflow).toBe('hidden')
+
+    vi.useFakeTimers()
+    try {
+      await wrapper.setProps({ open: false })
+      expect(wrapper.find('.aheart-drawer').classes()).toContain('is-leave')
+      expect(document.body.style.overflow).toBe('hidden')
+
+      await vi.advanceTimersByTimeAsync(241)
+      expect(document.body.style.overflow).toBe('')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('locks and restores the owner document for a custom container', () => {
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    const ownerDocument = iframe.contentDocument!
+    const wrapper = mountDrawer({
+      props: { open: true, title: 'Custom document', getContainer: () => ownerDocument.body }
+    })
+
+    expect(ownerDocument.body.style.overflow).toBe('hidden')
+    wrapper.unmount()
+    expect(ownerDocument.body.style.overflow).toBe('')
+    iframe.remove()
+  })
+
   it('treats destroyInactivePanel as a destroyOnHidden alias', async () => {
     const wrapper = mountDrawer({
       props: { open: true, destroyInactivePanel: true, title: 'Legacy destroy' },
@@ -1009,6 +1042,15 @@ describe('Drawer', () => {
     const locked = mountDrawer({ props: { open: true, keyboard: false } })
     await locked.find('.aheart-drawer').trigger('keydown', { key: 'Escape' })
     expect(locked.emitted('update:open')).toBeUndefined()
+  })
+
+  it('emits one close request for an attached Escape when the controlled owner rejects it', async () => {
+    const wrapper = mountDrawer({ attachTo: document.body, props: { open: true } })
+    await wrapper.get('.aheart-drawer').trigger('keydown', { key: 'Escape' })
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    expect(wrapper.props('open')).toBe(true)
   })
 
   it('does not render overlay nodes when closed', () => {

--- a/packages/components/src/drawer/drawer.vue
+++ b/packages/components/src/drawer/drawer.vue
@@ -95,6 +95,7 @@ import {
   defineComponent,
   getCurrentInstance,
   inject,
+  onBeforeMount,
   nextTick,
   onBeforeUnmount,
   onMounted,
@@ -110,6 +111,16 @@ import ASkeleton from '../skeleton'
 import { usePointerDrag } from '../utils/use-pointer-drag'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { useTeleportReady } from '../utils/use-teleport-ready'
+import {
+  getRecentPointerTarget,
+  isTopmost,
+  lockBodyScroll,
+  prepareOverlayDocument,
+  refreshOverlayStack,
+  registerOverlay,
+  unlockBodyScroll,
+  unregisterOverlay
+} from '../utils/overlay-controller'
 import {
   drawerEmits,
   drawerProps,
@@ -175,11 +186,51 @@ const panelRef = ref<HTMLElement | null>(null)
 const leaveFocusElement = ref<HTMLElement | null>(null)
 const titleId = `aheart-drawer-title-${instance?.uid ?? 'dialog'}`
 let pendingCloseCompletion = false
+let overlayRegistered = false
+const drawerId = Symbol('ADrawer')
+let overlayDocument: Document | null = null
+const effectiveZIndex = ref(props.zIndex)
 const resizedSize = ref<number>()
 const resizeStart = ref<{ size: number; clientX: number; clientY: number } | null>(null)
 
+const getDrawerDocument = () => {
+  const target = teleportTarget.value
+  return panelRef.value?.ownerDocument ??
+    triggerElement.value?.ownerDocument ??
+    (typeof target === 'object' && target ? target.ownerDocument : document)
+}
+const isDrawerTopmost = () => isTopmost(drawerId, overlayDocument ?? getDrawerDocument())
+
+const registerDrawerOverlay = () => {
+  if (overlayRegistered) return
+  const ownerDocument = getDrawerDocument()
+  registerOverlay({
+    id: drawerId,
+    document: ownerDocument,
+    getTrigger: () => triggerElement.value,
+    getContent: () => panelRef.value,
+    escapeEnabled: () => props.open && props.keyboard,
+    getBaseZIndex: () => props.zIndex,
+    onZIndexChange: (zIndex) => {
+      effectiveZIndex.value = zIndex
+    },
+    onEscape: close
+  })
+  lockBodyScroll(ownerDocument)
+  overlayDocument = ownerDocument
+  overlayRegistered = true
+}
+
+const unregisterDrawerOverlay = () => {
+  if (!overlayRegistered) return
+  const ownerDocument = overlayDocument ?? getDrawerDocument()
+  unregisterOverlay(drawerId, ownerDocument)
+  unlockBodyScroll(ownerDocument)
+  overlayDocument = null
+  overlayRegistered = false
+}
+
 const parentPushContext = inject<DrawerPushContext | null>(DRAWER_PUSH_CONTEXT, null)
-const drawerId = Symbol('ADrawer')
 const openChildDrawers = ref(new Map<symbol, true>())
 
 const setChildOpen = (id: symbol, open: boolean) => {
@@ -350,7 +401,7 @@ const panelStyle = computed(() => {
 const rootStyle = computed(() => ({
   ...props.rootStyle,
   ...semanticStyle('root'),
-  zIndex: props.zIndex
+  zIndex: effectiveZIndex.value
 }))
 
 const mergedMaskStyle = computed(() => ({
@@ -411,16 +462,21 @@ watch(
       pendingCloseCompletion = false
       leaveFocusElement.value = null
       if (motion.phase.value === 'hidden') captureTriggerElement()
+      registerDrawerOverlay()
       emit('afterOpenChange', true)
     }
 
     if (!open) {
       pendingCloseCompletion = true
-      const activeElement = document.activeElement
+      const ownerDocument = overlayDocument ?? getDrawerDocument()
+      const activeElement = ownerDocument.activeElement
+      const HTMLElementConstructor = ownerDocument.defaultView?.HTMLElement
       leaveFocusElement.value =
-        activeElement instanceof HTMLElement && panelRef.value?.contains(activeElement) ? activeElement : null
+        HTMLElementConstructor && activeElement instanceof HTMLElementConstructor && panelRef.value?.contains(activeElement)
+          ? activeElement as HTMLElement
+          : null
       void nextTick(() => {
-        if (motion.phase.value === 'leave' && leaveFocusElement.value && document.contains(leaveFocusElement.value)) {
+        if (motion.phase.value === 'leave' && leaveFocusElement.value && ownerDocument.contains(leaveFocusElement.value)) {
           leaveFocusElement.value.focus()
         }
       })
@@ -431,14 +487,23 @@ watch(
 )
 
 watch(
+  () => props.zIndex,
+  (zIndex) => {
+    if (overlayRegistered) refreshOverlayStack(overlayDocument ?? getDrawerDocument())
+    else effectiveZIndex.value = zIndex
+  }
+)
+
+watch(
   () => motion.phase.value,
   (phase) => {
     if (phase === 'entered' && props.open) {
-      void nextTick(() => focusPanel())
+      if (isDrawerTopmost()) void nextTick(() => focusPanel())
       return
     }
 
     if (phase === 'hidden' && !props.open && pendingCloseCompletion) {
+      unregisterDrawerOverlay()
       pendingCloseCompletion = false
       emit('afterOpenChange', false)
       void nextTick(() => restoreTriggerFocus())
@@ -455,7 +520,12 @@ watch(
   { immediate: true }
 )
 
+onBeforeMount(() => {
+  if (props.open) registerDrawerOverlay()
+})
+
 onBeforeUnmount(() => {
+  unregisterDrawerOverlay()
   parentPushContext?.setChildOpen(drawerId, false)
 })
 
@@ -472,13 +542,20 @@ const semanticStyle = (part: DrawerSemanticPart): CSSProperties | undefined =>
   resolveSemanticConfig(props.styles, part)
 
 const captureTriggerElement = () => {
-  triggerElement.value = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  const ownerDocument = getDrawerDocument()
+  const HTMLElementConstructor = ownerDocument.defaultView?.HTMLElement
+  const pointerTarget = getRecentPointerTarget(ownerDocument)
+  triggerElement.value = HTMLElementConstructor && pointerTarget instanceof HTMLElementConstructor
+    ? pointerTarget
+    : HTMLElementConstructor && ownerDocument.activeElement instanceof HTMLElementConstructor
+      ? ownerDocument.activeElement as HTMLElement
+      : null
 }
 
 const restoreTriggerFocus = () => {
   const target = triggerElement.value
 
-  if (!shouldFocusTriggerAfterClose.value || !target || !document.contains(target)) {
+  if (!shouldFocusTriggerAfterClose.value || !target || !target.ownerDocument.contains(target)) {
     return
   }
 
@@ -489,7 +566,7 @@ const isFocusableElementAvailable = (element: HTMLElement) =>
   !element.hasAttribute('hidden') &&
   element.getAttribute('aria-hidden') !== 'true' &&
   element.tabIndex >= 0 &&
-  !(element instanceof HTMLInputElement && element.type === 'hidden')
+  !(element.tagName === 'INPUT' && (element as HTMLInputElement).type === 'hidden')
 
 const getFocusableElements = () => {
   const panel = panelRef.value
@@ -502,7 +579,7 @@ const getFocusableElements = () => {
 }
 
 const focusPanel = () => {
-  if (!props.open) {
+  if (!props.open || !isDrawerTopmost()) {
     return
   }
 
@@ -513,6 +590,8 @@ const focusPanel = () => {
 }
 
 onMounted(() => {
+  prepareOverlayDocument(getDrawerDocument())
+
   if (!props.open) {
     return
   }
@@ -522,7 +601,7 @@ onMounted(() => {
 })
 
 const handleTrapTab = (event: KeyboardEvent) => {
-  if (!props.open || !shouldTrapFocus.value || event.key !== 'Tab') {
+  if (!props.open || !isDrawerTopmost() || !shouldTrapFocus.value || event.key !== 'Tab') {
     return
   }
 
@@ -535,7 +614,7 @@ const handleTrapTab = (event: KeyboardEvent) => {
   const focusableElements = getFocusableElements()
   const firstElement = focusableElements[0] ?? panel
   const lastElement = focusableElements[focusableElements.length - 1] ?? panel
-  const activeElement = document.activeElement
+  const activeElement = panel.ownerDocument.activeElement
 
   if (event.shiftKey) {
     if (activeElement === firstElement || !panel.contains(activeElement)) {
@@ -645,7 +724,18 @@ const handleMaskClick = () => {
 const handleKeydown = (event: KeyboardEvent) => {
   handleTrapTab(event)
 
-  if (props.keyboard && event.key === 'Escape') {
+  // The document capture listener owns normal browser events. Keep a local
+  // fallback for detached/custom-document hosts where the event never reaches it.
+  const ownerDocument = overlayDocument ?? getDrawerDocument()
+  if (
+    !event.composedPath().includes(ownerDocument) &&
+    props.open &&
+    props.keyboard &&
+    event.key === 'Escape' &&
+    isDrawerTopmost()
+  ) {
+    event.preventDefault()
+    event.stopPropagation()
     close()
   }
 }

--- a/packages/components/src/dropdown/__tests__/dropdown.test.ts
+++ b/packages/components/src/dropdown/__tests__/dropdown.test.ts
@@ -1,9 +1,11 @@
-import { mount } from '@vue/test-utils'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { h, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import ConfigProvider from '../../config-provider/config-provider.vue'
 import Dropdown, { DropdownButton } from '../index'
 import DropdownBase from '../dropdown.vue'
+
+enableAutoUnmount(afterEach)
 
 const menu = {
   items: [
@@ -849,5 +851,24 @@ describe('Dropdown', () => {
     expect(document.activeElement).toBe(wrapper.find('.dropdown-focus-target').element)
     wrapper.unmount()
     outside.remove()
+  })
+
+  it('cancels a pending hover open when click intent arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = mountDropdown({
+        props: { menu, trigger: ['hover', 'click'], mouseEnterDelay: 0.2 },
+        slots: { default: '<button>Actions</button>' }
+      })
+      const trigger = wrapper.find('.aheart-dropdown__trigger')
+      await trigger.trigger('mouseenter')
+      await trigger.trigger('click')
+      vi.advanceTimersByTime(200)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('openChange')?.filter(([, info]) => info?.source === 'trigger')).toHaveLength(1)
+      expect(wrapper.find('.aheart-dropdown__overlay').exists()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/components/src/dropdown/dropdown.vue
+++ b/packages/components/src/dropdown/dropdown.vue
@@ -304,6 +304,7 @@ const handleTriggerClick = () => {
     return
   }
 
+  clearHoverTimers()
   setOpen(!mergedOpen.value, { source: 'trigger' })
 }
 
@@ -325,6 +326,7 @@ const handleMouseLeave = (event: MouseEvent) => {
 
 const handleContextmenu = (event: MouseEvent) => {
   if (triggerSet.value.has('contextMenu')) {
+    clearHoverTimers()
     event.preventDefault()
     setOpen(true, { source: 'trigger' })
   }

--- a/packages/components/src/modal/__tests__/modal.test.ts
+++ b/packages/components/src/modal/__tests__/modal.test.ts
@@ -1,9 +1,11 @@
-import { mount } from '@vue/test-utils'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick, ref } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { enUS } from '../../config'
 import ConfigProvider from '../../config-provider/config-provider.vue'
 import Modal from '../modal.vue'
+
+enableAutoUnmount(afterEach)
 
 const mountModal = (options: Record<string, any> = {}) =>
   mount(Modal, {
@@ -610,6 +612,37 @@ describe('Modal', () => {
     }
   })
 
+  it('holds the body scroll lock until the leave motion is hidden', async () => {
+    const wrapper = mountModal({ props: { open: true, title: 'Scroll lock' } })
+    expect(document.body.style.overflow).toBe('hidden')
+
+    vi.useFakeTimers()
+    try {
+      await wrapper.setProps({ open: false })
+      expect(wrapper.find('.aheart-modal').classes()).toContain('is-leave')
+      expect(document.body.style.overflow).toBe('hidden')
+
+      await vi.advanceTimersByTimeAsync(181)
+      expect(document.body.style.overflow).toBe('')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('locks and restores the owner document for a custom container', () => {
+    const iframe = document.createElement('iframe')
+    document.body.appendChild(iframe)
+    const ownerDocument = iframe.contentDocument!
+    const wrapper = mountModal({
+      props: { open: true, title: 'Custom document', getContainer: () => ownerDocument.body }
+    })
+
+    expect(ownerDocument.body.style.overflow).toBe('hidden')
+    wrapper.unmount()
+    expect(ownerDocument.body.style.overflow).toBe('')
+    iframe.remove()
+  })
+
   it('does not emit afterClose when open changes to true', async () => {
     const wrapper = mountModal({
       props: { open: false, forceRender: true, title: 'Opening' }
@@ -734,6 +767,40 @@ describe('Modal', () => {
     wrapper.unmount()
     trigger.remove()
     outside.remove()
+  })
+
+  it('restores focus to a pointer opener even when the browser does not focus buttons on click', async () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          const open = ref(false)
+          return () => h('div', [
+            h('button', { class: 'pointer-opener', onClick: () => (open.value = true) }, [h('span', 'Open')]),
+            h(Modal, {
+              open: open.value,
+              title: 'Pointer modal',
+              getContainer: false,
+              'onUpdate:open': (value: boolean) => (open.value = value)
+            })
+          ])
+        }
+      }),
+      { attachTo: document.body }
+    )
+    const trigger = wrapper.get('.pointer-opener')
+    await trigger.get('span').trigger('pointerdown')
+    await trigger.trigger('click')
+    await nextTick()
+
+    vi.useFakeTimers()
+    try {
+      await wrapper.get('.aheart-modal').trigger('keydown', { key: 'Escape' })
+      await vi.advanceTimersByTimeAsync(181)
+      await nextTick()
+      expect(document.activeElement).toBe(trigger.element)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('lets focusable config control trigger focus restoration', async () => {
@@ -1115,6 +1182,15 @@ describe('Modal', () => {
     const locked = mountModal({ props: { open: true, keyboard: false } })
     await locked.find('.aheart-modal').trigger('keydown', { key: 'Escape' })
     expect(locked.emitted('update:open')).toBeUndefined()
+  })
+
+  it('emits one close request for an attached Escape when the controlled owner rejects it', async () => {
+    const wrapper = mountModal({ attachTo: document.body, props: { open: true } })
+    await wrapper.get('.aheart-modal').trigger('keydown', { key: 'Escape' })
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    expect(wrapper.props('open')).toBe(true)
   })
 
   it('renders custom closeIcon content and hides the close button when closeIcon is false', () => {

--- a/packages/components/src/modal/modal.vue
+++ b/packages/components/src/modal/modal.vue
@@ -1,20 +1,3 @@
-<script lang="ts">
-const openModalStack: symbol[] = []
-
-const registerOpenModal = (id: symbol) => {
-  const previousIndex = openModalStack.indexOf(id)
-  if (previousIndex >= 0) openModalStack.splice(previousIndex, 1)
-  openModalStack.push(id)
-}
-
-const unregisterOpenModal = (id: symbol) => {
-  const index = openModalStack.indexOf(id)
-  if (index >= 0) openModalStack.splice(index, 1)
-}
-
-const isTopmostOpenModal = (id: symbol) => openModalStack[openModalStack.length - 1] === id
-</script>
-
 <template>
   <Teleport :to="teleportTo" :disabled="!shouldTeleport">
     <div
@@ -110,6 +93,16 @@ import {
   type ModalSemanticPart,
   type ModalWidth
 } from './types'
+import {
+  getRecentPointerTarget,
+  isTopmost,
+  lockBodyScroll,
+  prepareOverlayDocument,
+  refreshOverlayStack,
+  registerOverlay,
+  unlockBodyScroll,
+  unregisterOverlay
+} from '../utils/overlay-controller'
 import './style.css'
 
 defineOptions({
@@ -142,6 +135,46 @@ const leaveFocusElement = ref<HTMLElement | null>(null)
 const modalStackId = Symbol('aheart-modal')
 const titleId = `aheart-modal-title-${instance?.uid ?? 'dialog'}`
 let pendingCloseCompletion = false
+let overlayRegistered = false
+let overlayDocument: Document | null = null
+const effectiveZIndex = ref(props.zIndex)
+
+const getModalDocument = () => {
+  const target = teleportTarget.value
+  return dialogRef.value?.ownerDocument ??
+    triggerElement.value?.ownerDocument ??
+    (typeof target === 'object' && target ? target.ownerDocument : document)
+}
+const isModalTopmost = () => isTopmost(modalStackId, overlayDocument ?? getModalDocument())
+
+const registerModalOverlay = () => {
+  if (overlayRegistered) return
+  const ownerDocument = getModalDocument()
+  registerOverlay({
+    id: modalStackId,
+    document: ownerDocument,
+    getTrigger: () => triggerElement.value,
+    getContent: () => dialogRef.value,
+    escapeEnabled: () => props.open && props.keyboard,
+    getBaseZIndex: () => props.zIndex,
+    onZIndexChange: (zIndex) => {
+      effectiveZIndex.value = zIndex
+    },
+    onEscape: close
+  })
+  lockBodyScroll(ownerDocument)
+  overlayDocument = ownerDocument
+  overlayRegistered = true
+}
+
+const unregisterModalOverlay = () => {
+  if (!overlayRegistered) return
+  const ownerDocument = overlayDocument ?? getModalDocument()
+  unregisterOverlay(modalStackId, ownerDocument)
+  unlockBodyScroll(ownerDocument)
+  overlayDocument = null
+  overlayRegistered = false
+}
 
 const AModalRenderNode = defineComponent({
   name: 'AModalRenderNode',
@@ -243,7 +276,7 @@ const dialogStyle = computed(() => ({
 const rootStyle = computed(() => ({
   ...props.rootStyle,
   ...semanticStyle('root'),
-  zIndex: props.zIndex
+  zIndex: effectiveZIndex.value
 }))
 
 const hasTitle = computed(() => Boolean(slots.title) || hasRenderable(props.title))
@@ -363,21 +396,24 @@ watch(
   () => props.open,
   (open, previousOpen) => {
     if (open && !previousOpen) {
-      registerOpenModal(modalStackId)
       pendingCloseCompletion = false
       leaveFocusElement.value = null
       if (motion.phase.value === 'hidden') captureTriggerElement()
+      registerModalOverlay()
       emit('afterOpenChange', true)
     }
 
     if (!open) {
-      unregisterOpenModal(modalStackId)
       pendingCloseCompletion = true
-      const activeElement = document.activeElement
+      const ownerDocument = overlayDocument ?? getModalDocument()
+      const activeElement = ownerDocument.activeElement
+      const HTMLElementConstructor = ownerDocument.defaultView?.HTMLElement
       leaveFocusElement.value =
-        activeElement instanceof HTMLElement && dialogRef.value?.contains(activeElement) ? activeElement : null
+        HTMLElementConstructor && activeElement instanceof HTMLElementConstructor && dialogRef.value?.contains(activeElement)
+          ? activeElement as HTMLElement
+          : null
       void nextTick(() => {
-        if (motion.phase.value === 'leave' && leaveFocusElement.value && document.contains(leaveFocusElement.value)) {
+        if (motion.phase.value === 'leave' && leaveFocusElement.value && ownerDocument.contains(leaveFocusElement.value)) {
           leaveFocusElement.value.focus()
         }
       })
@@ -387,9 +423,17 @@ watch(
 )
 
 watch(
+  () => props.zIndex,
+  (zIndex) => {
+    if (overlayRegistered) refreshOverlayStack(overlayDocument ?? getModalDocument())
+    else effectiveZIndex.value = zIndex
+  }
+)
+
+watch(
   () => props.open,
   (open) => {
-    if (open && isTopmostOpenModal(modalStackId)) focusDialog()
+    if (open && isModalTopmost()) focusDialog()
   },
   { flush: 'post' }
 )
@@ -397,12 +441,13 @@ watch(
 watch(
   () => motion.phase.value,
   (phase) => {
-    if (phase === 'entered' && props.open && isTopmostOpenModal(modalStackId)) {
+    if (phase === 'entered' && props.open && isModalTopmost()) {
       void nextTick(() => focusDialog())
       return
     }
 
     if (phase === 'hidden' && !props.open && pendingCloseCompletion) {
+      unregisterModalOverlay()
       pendingCloseCompletion = false
       emit('afterOpenChange', false)
       emit('afterClose')
@@ -438,13 +483,20 @@ const semanticStyles = (...parts: ModalSemanticPart[]): CSSProperties | undefine
 }
 
 const captureTriggerElement = () => {
-  triggerElement.value = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  const ownerDocument = getModalDocument()
+  const HTMLElementConstructor = ownerDocument.defaultView?.HTMLElement
+  const pointerTarget = getRecentPointerTarget(ownerDocument)
+  triggerElement.value = HTMLElementConstructor && pointerTarget instanceof HTMLElementConstructor
+    ? pointerTarget
+    : HTMLElementConstructor && ownerDocument.activeElement instanceof HTMLElementConstructor
+      ? ownerDocument.activeElement as HTMLElement
+      : null
 }
 
 const restoreTriggerFocus = () => {
   const target = triggerElement.value
 
-  if (!shouldFocusTriggerAfterClose.value || !target || !document.contains(target)) {
+  if (!shouldFocusTriggerAfterClose.value || !target || !target.ownerDocument.contains(target)) {
     return
   }
 
@@ -455,7 +507,7 @@ const isFocusableElementAvailable = (element: HTMLElement) =>
   !element.hasAttribute('hidden') &&
   element.getAttribute('aria-hidden') !== 'true' &&
   element.tabIndex >= 0 &&
-  !(element instanceof HTMLInputElement && element.type === 'hidden')
+  !(element.tagName === 'INPUT' && (element as HTMLInputElement).type === 'hidden')
 
 const getFocusableElements = () => {
   const dialog = dialogRef.value
@@ -479,13 +531,13 @@ const focusDialog = () => {
 }
 
 onBeforeMount(() => {
-  if (props.open) registerOpenModal(modalStackId)
+  if (props.open) registerModalOverlay()
 })
 
 onMounted(() => {
-  document.addEventListener('keydown', handleEnteringKeydown)
+  prepareOverlayDocument(getModalDocument())
 
-  if (!props.open || !isTopmostOpenModal(modalStackId)) {
+  if (!props.open || !isModalTopmost()) {
     return
   }
 
@@ -493,12 +545,11 @@ onMounted(() => {
   focusDialog()
 })
 onBeforeUnmount(() => {
-  document.removeEventListener('keydown', handleEnteringKeydown)
-  unregisterOpenModal(modalStackId)
+  unregisterModalOverlay()
 })
 
 const handleTrapTab = (event: KeyboardEvent) => {
-  if (!props.open || !shouldTrapFocus.value || event.key !== 'Tab') {
+  if (!props.open || !isModalTopmost() || !shouldTrapFocus.value || event.key !== 'Tab') {
     return
   }
 
@@ -511,7 +562,7 @@ const handleTrapTab = (event: KeyboardEvent) => {
   const focusableElements = getFocusableElements()
   const firstElement = focusableElements[0] ?? dialog
   const lastElement = focusableElements[focusableElements.length - 1] ?? dialog
-  const activeElement = document.activeElement
+  const activeElement = dialog.ownerDocument.activeElement
 
   if (event.shiftKey) {
     if (activeElement === firstElement || !dialog.contains(activeElement)) {
@@ -561,27 +612,19 @@ const handleMaskClick = () => {
   }
 }
 
-const handleEnteringKeydown = (event: KeyboardEvent) => {
-  if (
-    !props.open ||
-    !props.keyboard ||
-    event.key !== 'Escape' ||
-    motion.phase.value !== 'enter' ||
-    document.activeElement !== triggerElement.value ||
-    !isTopmostOpenModal(modalStackId)
-  ) {
-    return
-  }
-
-  event.preventDefault()
-  event.stopPropagation()
-  close()
-}
-
 const handleKeydown = (event: KeyboardEvent) => {
   handleTrapTab(event)
 
-  if (props.keyboard && event.key === 'Escape' && isTopmostOpenModal(modalStackId)) {
+  // The document capture listener owns normal browser events. Keep a local
+  // fallback for detached/custom-document hosts where the event never reaches it.
+  const ownerDocument = overlayDocument ?? getModalDocument()
+  if (
+    !event.composedPath().includes(ownerDocument) &&
+    props.open &&
+    props.keyboard &&
+    event.key === 'Escape' &&
+    isModalTopmost()
+  ) {
     event.preventDefault()
     event.stopPropagation()
     close()

--- a/packages/components/src/popconfirm/__tests__/popconfirm.test.ts
+++ b/packages/components/src/popconfirm/__tests__/popconfirm.test.ts
@@ -1,7 +1,9 @@
-import { mount } from '@vue/test-utils'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { h, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import Popconfirm from '../popconfirm.vue'
+
+enableAutoUnmount(afterEach)
 
 const createRect = ({ left, top, width, height }: { left: number; top: number; width: number; height: number }) =>
   ({
@@ -700,5 +702,45 @@ describe('Popconfirm', () => {
     expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
     wrapper.unmount()
     outside.remove()
+  })
+
+  it('keeps focus popconfirm open while focus moves into its teleported popup', async () => {
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    const wrapper = mountPopconfirm({
+      attachTo: document.body,
+      props: { title: 'Delete?', trigger: 'focus' },
+      slots: { default: '<button>Delete</button>' }
+    })
+    const trigger = wrapper.find('.aheart-popconfirm__trigger')
+    await trigger.trigger('focusin')
+    const popup = wrapper.find('.aheart-popconfirm__popup')
+    const popupButton = wrapper.find<HTMLElement>('.aheart-popconfirm__cancel')
+    expect(trigger.attributes('aria-controls')).toBe(popup.attributes('id'))
+    expect(wrapper.get('.aheart-popconfirm__trigger > button').attributes('aria-controls')).toBe(popup.attributes('id'))
+    expect(wrapper.get('.aheart-popconfirm__trigger > button').attributes('aria-expanded')).toBe('true')
+    await trigger.trigger('focusout', { relatedTarget: popupButton.element })
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([true])
+    await popupButton.trigger('focusout', { relatedTarget: outside })
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
+    wrapper.unmount()
+    outside.remove()
+  })
+
+  it('cancels a pending hover open when click intent arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = mountPopconfirm({
+        props: { title: 'Delete?', trigger: ['hover', 'click'], mouseEnterDelay: 0.2 },
+        slots: { default: '<button>Delete</button>' }
+      })
+      const trigger = wrapper.find('.aheart-popconfirm__trigger')
+      await trigger.trigger('mouseenter')
+      await trigger.trigger('click')
+      await vi.advanceTimersByTimeAsync(200)
+      expect(wrapper.emitted('openChange')?.filter(([open]) => open)).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/components/src/popconfirm/popconfirm.vue
+++ b/packages/components/src/popconfirm/popconfirm.vue
@@ -10,6 +10,8 @@
     <span
       ref="triggerRef"
       class="aheart-popconfirm__trigger"
+      :aria-controls="popupId"
+      :aria-expanded="mergedOpen ? 'true' : 'false'"
       :class="triggerClass"
       :style="triggerStyle"
       @mouseenter="handleMouseEnter"
@@ -27,12 +29,15 @@
         v-show="motion.phase.value !== 'hidden'"
         ref="popupRef"
         class="aheart-popconfirm__popup"
+        :id="popupId"
         :class="popupClass"
         :style="popupStyle"
         role="dialog"
+        :aria-labelledby="hasTitle ? titleId : undefined"
         :aria-hidden="motion.phase.value === 'hidden' ? 'true' : undefined"
         @mouseenter="handleMouseEnter"
         @mouseleave="handleMouseLeave"
+        @focusout="handleFocusOut"
         @click="handlePopupClick"
       >
         <span
@@ -57,7 +62,7 @@
               </slot>
             </span>
             <span class="aheart-popconfirm__text" :class="textClass" :style="textStyle">
-              <span v-if="hasTitle" class="aheart-popconfirm__title" :class="titleClass" :style="titleStyle">
+              <span v-if="hasTitle" :id="titleId" class="aheart-popconfirm__title" :class="titleClass" :style="titleStyle">
                 <slot name="title">
                   <ARenderNode :node="title" />
                 </slot>
@@ -110,6 +115,8 @@ import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { useTeleportReady } from '../utils/use-teleport-ready'
+import { useStableId } from '../utils/use-stable-id'
+import { useTriggerAria } from '../utils/use-trigger-aria'
 import {
   popconfirmEmits,
   popconfirmProps,
@@ -147,6 +154,8 @@ const innerOpen = ref(props.defaultOpen)
 const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const popupRef = ref<HTMLElement | null>(null)
+const popupId = useStableId(undefined, 'aheart-popconfirm')
+const titleId = useStableId(undefined, 'aheart-popconfirm-title')
 const arrowRef = ref<HTMLElement | null>(null)
 const effectivePlacement = ref<FloatingPlacement>(props.placement)
 const isControlled = computed(() => props.open !== undefined)
@@ -181,6 +190,10 @@ const floatingPosition = useFloatingPosition({
 const resolvedIcon = computed<PopconfirmContent>(() => (props.icon === undefined ? '!' : props.icon))
 const hasIcon = computed(() => Boolean(slots.icon) || hasRenderable(resolvedIcon.value))
 const hasTitle = computed(() => Boolean(slots.title) || hasRenderable(props.title))
+useTriggerAria(triggerRef, () => ({
+  'aria-controls': popupId.value,
+  'aria-expanded': mergedOpen.value ? 'true' : 'false'
+}))
 const hasDescription = computed(() => Boolean(slots.description) || hasRenderable(props.description))
 const semanticInfo = computed<PopconfirmSemanticInfo>(() => ({
   open: visible.value,
@@ -365,24 +378,32 @@ const handleMouseLeave = (event: MouseEvent) => {
 
 const handleFocusIn = () => {
   if (normalizedTriggers.value.has('focus')) {
+    clearHoverTimers()
     requestOpen(true)
   }
 }
 
-const handleFocusOut = () => {
+const handleFocusOut = (event: FocusEvent) => {
   if (normalizedTriggers.value.has('focus')) {
+    clearHoverTimers()
+    const nextTarget = event.relatedTarget
+    if (nextTarget instanceof Node && (rootRef.value?.contains(nextTarget) || popupRef.value?.contains(nextTarget))) {
+      return
+    }
     requestOpen(false)
   }
 }
 
 const handleClick = () => {
   if (normalizedTriggers.value.has('click')) {
+    clearHoverTimers()
     requestOpen(!mergedOpen.value)
   }
 }
 
 const handleContextmenu = (event: MouseEvent) => {
   if (normalizedTriggers.value.has('contextMenu')) {
+    clearHoverTimers()
     event.preventDefault()
     requestOpen(true)
   }

--- a/packages/components/src/popover/__tests__/popover.test.ts
+++ b/packages/components/src/popover/__tests__/popover.test.ts
@@ -1,7 +1,9 @@
-import { mount } from '@vue/test-utils'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { h, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import Popover from '../popover.vue'
+
+enableAutoUnmount(afterEach)
 
 const createRect = ({ left, top, width, height }: { left: number; top: number; width: number; height: number }) =>
   ({
@@ -579,5 +581,45 @@ describe('Popover', () => {
     expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
     wrapper.unmount()
     outside.remove()
+  })
+
+  it('keeps focus popover open while focus moves into its teleported popup', async () => {
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    const wrapper = mountPopover({
+      attachTo: document.body,
+      props: { title: 'Details', content: 'Content', trigger: 'focus' },
+      slots: { default: '<button>Open</button>', content: '<button class="popover-popup-focus">Content</button>' }
+    })
+    const trigger = wrapper.find('.aheart-popover__trigger')
+    await trigger.trigger('focusin')
+    const popup = wrapper.find('.aheart-popover__popup')
+    const popupButton = wrapper.find<HTMLElement>('.popover-popup-focus')
+    expect(trigger.attributes('aria-controls')).toBe(popup.attributes('id'))
+    expect(wrapper.get('.aheart-popover__trigger > button').attributes('aria-controls')).toBe(popup.attributes('id'))
+    expect(wrapper.get('.aheart-popover__trigger > button').attributes('aria-expanded')).toBe('true')
+    await trigger.trigger('focusout', { relatedTarget: popupButton.element })
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([true])
+    await popupButton.trigger('focusout', { relatedTarget: outside })
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
+    wrapper.unmount()
+    outside.remove()
+  })
+
+  it('cancels a pending hover open when click intent arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = mountPopover({
+        props: { content: 'Content', trigger: ['hover', 'click'], mouseEnterDelay: 0.2 },
+        slots: { default: '<button>Open</button>' }
+      })
+      const trigger = wrapper.find('.aheart-popover__trigger')
+      await trigger.trigger('mouseenter')
+      await trigger.trigger('click')
+      await vi.advanceTimersByTimeAsync(200)
+      expect(wrapper.emitted('openChange')?.filter(([open]) => open)).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/components/src/popover/popover.vue
+++ b/packages/components/src/popover/popover.vue
@@ -10,6 +10,8 @@
     <span
       ref="triggerRef"
       class="aheart-popover__trigger"
+      :aria-controls="popupId"
+      :aria-expanded="mergedOpen ? 'true' : 'false'"
       :class="triggerClass"
       :style="triggerStyle"
       @mouseenter="handleMouseEnter"
@@ -27,12 +29,15 @@
         v-show="motion.phase.value !== 'hidden'"
         ref="popupRef"
         class="aheart-popover__popup"
+        :id="popupId"
         :class="popupClass"
         :style="popupStyle"
         role="dialog"
+        :aria-labelledby="hasTitle ? titleId : undefined"
         :aria-hidden="motion.phase.value === 'hidden' ? 'true' : undefined"
         @mouseenter="handleMouseEnter"
         @mouseleave="handleMouseLeave"
+        @focusout="handleFocusOut"
       >
         <span
           v-if="showArrow"
@@ -43,7 +48,7 @@
           aria-hidden="true"
         />
         <span class="aheart-popover__container" :class="containerClass" :style="containerStyle">
-          <span v-if="hasTitle" class="aheart-popover__title" :class="titleClass" :style="titleStyle">
+          <span v-if="hasTitle" :id="titleId" class="aheart-popover__title" :class="titleClass" :style="titleStyle">
             <slot name="title">
               <ARenderNode :node="title" />
             </slot>
@@ -67,6 +72,8 @@ import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { useTeleportReady } from '../utils/use-teleport-ready'
+import { useStableId } from '../utils/use-stable-id'
+import { useTriggerAria } from '../utils/use-trigger-aria'
 import {
   popoverEmits,
   popoverProps,
@@ -104,6 +111,8 @@ const innerOpen = ref(props.defaultOpen)
 const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const popupRef = ref<HTMLElement | null>(null)
+const popupId = useStableId(undefined, 'aheart-popover')
+const titleId = useStableId(undefined, 'aheart-popover-title')
 const arrowRef = ref<HTMLElement | null>(null)
 const effectivePlacement = ref<FloatingPlacement>(props.placement)
 let mouseEnterTimer: ReturnType<typeof setTimeout> | undefined
@@ -113,6 +122,10 @@ const isControlled = computed(() => props.open !== undefined)
 const mergedOpen = computed(() => props.open ?? innerOpen.value)
 const normalizedTriggers = computed(() => new Set(normalizeFloatingTriggers(props.trigger)))
 const hasTitle = computed(() => Boolean(slots.title) || hasRenderable(props.title))
+useTriggerAria(triggerRef, () => ({
+  'aria-controls': popupId.value,
+  'aria-expanded': mergedOpen.value ? 'true' : 'false'
+}))
 const hasContent = computed(() => Boolean(slots.content) || hasRenderable(props.content))
 const hasPopupContent = computed(() => hasTitle.value || hasContent.value)
 const visible = computed(() => hasPopupContent.value && mergedOpen.value)
@@ -286,24 +299,32 @@ const handleMouseLeave = (event: MouseEvent) => {
 
 const handleFocusIn = () => {
   if (normalizedTriggers.value.has('focus')) {
+    clearHoverTimers()
     requestOpen(true)
   }
 }
 
-const handleFocusOut = () => {
+const handleFocusOut = (event: FocusEvent) => {
   if (normalizedTriggers.value.has('focus')) {
+    clearHoverTimers()
+    const nextTarget = event.relatedTarget
+    if (nextTarget instanceof Node && (rootRef.value?.contains(nextTarget) || popupRef.value?.contains(nextTarget))) {
+      return
+    }
     requestOpen(false)
   }
 }
 
 const handleClick = () => {
   if (normalizedTriggers.value.has('click')) {
+    clearHoverTimers()
     requestOpen(!mergedOpen.value)
   }
 }
 
 const handleContextmenu = (event: MouseEvent) => {
   if (normalizedTriggers.value.has('contextMenu')) {
+    clearHoverTimers()
     event.preventDefault()
     requestOpen(true)
   }

--- a/packages/components/src/tooltip/__tests__/tooltip.test.ts
+++ b/packages/components/src/tooltip/__tests__/tooltip.test.ts
@@ -1,7 +1,9 @@
-import { mount } from '@vue/test-utils'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { h, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import Tooltip from '../tooltip.vue'
+
+enableAutoUnmount(afterEach)
 
 const createRect = ({ left, top, width, height }: { left: number; top: number; width: number; height: number }) =>
   ({
@@ -638,5 +640,46 @@ describe('Tooltip', () => {
     expect(document.activeElement).toBe(wrapper.find('.tooltip-focus-target').element)
     wrapper.unmount()
     outside.remove()
+  })
+
+  it('keeps focus tooltip open while focus moves into its teleported popup', async () => {
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    const wrapper = mountTooltip({
+      attachTo: document.body,
+      props: { title: 'Help', trigger: 'focus' },
+      slots: { default: '<button aria-describedby="help-copy">Help</button>', title: '<button class="tooltip-popup-focus">More</button>' }
+    })
+    const trigger = wrapper.find('.aheart-tooltip__trigger')
+    await trigger.trigger('focusin')
+    const popup = wrapper.find('.aheart-tooltip__popup')
+    const popupButton = wrapper.find<HTMLElement>('.tooltip-popup-focus')
+    expect(trigger.attributes('aria-describedby')).toBe(popup.attributes('id'))
+    expect(wrapper.get('.aheart-tooltip__trigger > button').attributes('aria-describedby')).toBe(`help-copy ${popup.attributes('id')}`)
+    await trigger.trigger('focusout', { relatedTarget: popupButton.element })
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([true])
+    await popupButton.trigger('focusout', { relatedTarget: outside })
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
+    wrapper.unmount()
+    outside.remove()
+  })
+
+  it('cancels a pending hover open when click intent arrives', async () => {
+    vi.useFakeTimers()
+    try {
+      const wrapper = mountTooltip({
+        props: { title: 'Help', trigger: ['hover', 'click'], mouseEnterDelay: 0.2 },
+        slots: { default: '<button>Help</button>' }
+      })
+      const trigger = wrapper.find('.aheart-tooltip__trigger')
+      await trigger.trigger('mouseenter')
+      await trigger.trigger('click')
+      vi.advanceTimersByTime(200)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('openChange')?.filter(([open]) => open)).toHaveLength(1)
+      expect(wrapper.find('.aheart-tooltip__popup').exists()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/components/src/tooltip/tooltip.vue
+++ b/packages/components/src/tooltip/tooltip.vue
@@ -10,6 +10,7 @@
     <span
       ref="triggerRef"
       class="aheart-tooltip__trigger"
+      :aria-describedby="hasTitle ? popupId : undefined"
       :class="triggerClass"
       :style="triggerStyle"
       @mouseenter="handleMouseEnter"
@@ -27,12 +28,14 @@
         v-show="motion.phase.value !== 'hidden'"
         ref="popupRef"
         class="aheart-tooltip__popup"
+        :id="popupId"
         :class="popupClass"
         :style="popupStyle"
         role="tooltip"
         :aria-hidden="motion.phase.value === 'hidden' ? 'true' : undefined"
         @mouseenter="handleMouseEnter"
         @mouseleave="handleMouseLeave"
+        @focusout="handleFocusOut"
       >
         <span
           v-if="showArrow"
@@ -62,6 +65,8 @@ import { useFloatingDismiss } from '../utils/use-floating-dismiss'
 import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { useTeleportReady } from '../utils/use-teleport-ready'
+import { useStableId } from '../utils/use-stable-id'
+import { useTriggerAria } from '../utils/use-trigger-aria'
 import {
   tooltipEmits,
   tooltipProps,
@@ -100,12 +105,16 @@ const innerOpen = ref(props.defaultOpen)
 const rootRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 const popupRef = ref<HTMLElement | null>(null)
+const popupId = useStableId(undefined, 'aheart-tooltip')
 const arrowRef = ref<HTMLElement | null>(null)
 const effectivePlacement = ref<FloatingPlacement>(props.placement)
 const isControlled = computed(() => props.open !== undefined)
 const mergedOpen = computed(() => props.open ?? innerOpen.value)
 const normalizedTriggers = computed(() => new Set(normalizeFloatingTriggers(props.trigger)))
 const hasTitle = computed(() => Boolean(slots.title) || hasTitleContent(props.title))
+useTriggerAria(triggerRef, () => ({
+  'aria-describedby': hasTitle.value ? popupId.value : undefined
+}))
 const visible = computed(() => hasTitle.value && mergedOpen.value)
 const shouldDestroyOnHidden = computed(() => props.destroyOnHidden || props.destroyTooltipOnHide)
 const motion = useMotionPresence(visible, { destroyOnHidden: shouldDestroyOnHidden, duration: 120 })
@@ -256,24 +265,32 @@ const handleMouseLeave = (event: MouseEvent) => {
 
 const handleFocusIn = () => {
   if (normalizedTriggers.value.has('focus')) {
+    clearTimers()
     requestOpen(true)
   }
 }
 
-const handleFocusOut = () => {
+const handleFocusOut = (event: FocusEvent) => {
   if (normalizedTriggers.value.has('focus')) {
+    clearTimers()
+    const nextTarget = event.relatedTarget
+    if (nextTarget instanceof Node && (rootRef.value?.contains(nextTarget) || popupRef.value?.contains(nextTarget))) {
+      return
+    }
     requestOpen(false)
   }
 }
 
 const handleClick = () => {
   if (normalizedTriggers.value.has('click')) {
+    clearTimers()
     requestOpen(!mergedOpen.value)
   }
 }
 
 const handleContextmenu = (event: MouseEvent) => {
   if (normalizedTriggers.value.has('contextMenu')) {
+    clearTimers()
     event.preventDefault()
     requestOpen(true)
   }

--- a/packages/components/src/tree-select/__tests__/tree-select.test.ts
+++ b/packages/components/src/tree-select/__tests__/tree-select.test.ts
@@ -1,6 +1,8 @@
-import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
 import TreeSelect from '../tree-select.vue'
+
+enableAutoUnmount(afterEach)
 
 const mountTreeSelect = (options: Record<string, any> = {}) => mount(TreeSelect, {
   ...options,
@@ -13,6 +15,35 @@ const treeData = [
 ]
 
 describe('TreeSelect', () => {
+  it('connects combobox, dialog, and visible tree active descendant', async () => {
+    const wrapper = mountTreeSelect({ attrs: { 'aria-describedby': 'tree-help' }, props: { treeData } })
+    const trigger = wrapper.get('.aheart-tree-select__trigger')
+    await trigger.trigger('click')
+    const panel = wrapper.get('.aheart-tree-select__panel')
+    expect(trigger.attributes('aria-controls')).toBe(panel.attributes('id'))
+    expect(trigger.attributes('aria-describedby')).toBe('tree-help')
+    const node = wrapper.get('[data-tree-key="workspace"]')
+    await node.trigger('focusin')
+    const activeId = trigger.attributes('aria-activedescendant')
+    expect(activeId).toBe(node.attributes('id'))
+    expect(panel.element.querySelector(`#${activeId}`)).toBe(node.element)
+  })
+
+  it('clears a stale active descendant after search filters the focused node', async () => {
+    const wrapper = mountTreeSelect({ props: { treeData, showSearch: true } })
+    const trigger = wrapper.get('.aheart-tree-select__trigger')
+    await trigger.trigger('click')
+    const workspace = wrapper.get('[data-tree-key="workspace"]')
+    await workspace.trigger('focusin')
+    expect(trigger.attributes('aria-activedescendant')).toBe(workspace.attributes('id'))
+
+    await wrapper.get('input[type="search"]').setValue('Archive')
+    expect(trigger.attributes('aria-activedescendant')).toBeUndefined()
+    const archive = wrapper.get('[data-tree-key="archive"]')
+    await archive.trigger('focusin')
+    expect(trigger.attributes('aria-activedescendant')).toBe(archive.attributes('id'))
+  })
+
   it('opens a tree and emits a selected value', async () => {
     const wrapper = mountTreeSelect({ props: { treeData, placeholder: 'Choose a page' } })
 

--- a/packages/components/src/tree-select/tree-select.vue
+++ b/packages/components/src/tree-select/tree-select.vue
@@ -9,6 +9,9 @@
       :aria-expanded="mergedOpen ? 'true' : 'false'"
       :aria-disabled="disabled ? 'true' : undefined"
       :aria-labelledby="resolvedAriaLabelledby"
+      :aria-controls="panelId"
+      :aria-activedescendant="activeNodeId"
+      :aria-describedby="resolvedAriaDescribedby"
       aria-haspopup="tree"
       @click="toggleOpen"
       @keydown="handleTriggerKeydown"
@@ -38,6 +41,12 @@
       class="aheart-tree-select__panel"
       :class="panelClass"
       :style="panelStyle"
+      :id="panelId"
+      role="dialog"
+      :aria-labelledby="resolvedAriaLabelledby || undefined"
+      :aria-describedby="resolvedAriaDescribedby || undefined"
+      :aria-label="resolvedAriaLabelledby ? undefined : '树选择'"
+      @focusin="handleTreeFocusin"
     >
       <input
         v-if="showSearch"
@@ -48,6 +57,7 @@
         aria-label="搜索树节点"
       />
       <ATree
+        :id="treeId"
         :tree-data="filteredTreeData"
         :selected-keys="selectedKeys"
         :expanded-keys="searchText ? searchExpandedKeys : undefined"
@@ -72,6 +82,7 @@ import { useFloatingPosition } from '../utils/use-floating-position'
 import { useMotionPresence } from '../utils/use-motion-presence'
 import { usePropPresence } from '../utils/use-prop-presence'
 import { useControllableState } from '../utils/use-controllable-state'
+import { useStableId } from '../utils/use-stable-id'
 import { useTeleportReady } from '../utils/use-teleport-ready'
 import './style.css'
 
@@ -104,6 +115,9 @@ const props = withDefaults(defineProps<{
   autoAdjustOverflow: true
 })
 const attrs = useAttrs()
+const instanceId = useStableId(undefined, 'aheart-tree-select').value
+const panelId = `aheart-tree-select-panel-${instanceId}`
+const treeId = `aheart-tree-select-tree-${instanceId}`
 const emit = defineEmits<{
   'update:modelValue': [value: TreeSelectValue]
   change: [value: TreeSelectValue]
@@ -118,6 +132,7 @@ const searchText = ref('')
 const isControlled = usePropPresence('modelValue', 'model-value')
 const isOpenControlled = usePropPresence('open')
 const resolvedAriaLabelledby = computed(() => props.labelledBy ?? props.ariaLabelledby ?? attrs['aria-labelledby'] as string | undefined)
+const resolvedAriaDescribedby = computed(() => attrs['aria-describedby'] as string | undefined)
 const openState = useControllableState({
   controlled: () => props.open,
   isControlled: isOpenControlled,
@@ -161,6 +176,31 @@ const filteredTreeData = computed(() => {
   const query = searchText.value.trim().toLowerCase()
   return query ? filterNodes(props.treeData, query) : props.treeData
 })
+const activeKey = ref<TreeKey | undefined>()
+const nodeId = (key: TreeKey) => `${instanceId}-node-${encodeURIComponent(String(key)).replaceAll('%', '_')}`
+const activeNodeId = computed(() => {
+  if (!mergedOpen.value || activeKey.value === undefined) return undefined
+  return flattenNodes(filteredTreeData.value).some((node) => String(node.key) === String(activeKey.value))
+    ? nodeId(activeKey.value)
+    : undefined
+})
+const syncTreeNodeIds = () => {
+  for (const element of Array.from(panelRef.value?.querySelectorAll<HTMLElement>('[data-tree-key]') ?? [])) {
+    const key = element.dataset.treeKey
+    if (key !== undefined) element.id = nodeId(key)
+  }
+}
+watch([filteredTreeData, mergedOpen], ([, open]) => {
+  if (open) void nextTick(syncTreeNodeIds)
+}, { flush: 'post' })
+const handleTreeFocusin = (event: FocusEvent) => {
+  const node = (event.target as HTMLElement).closest<HTMLElement>('[data-tree-key]')
+  if (node?.dataset.treeKey !== undefined) {
+    const key = node.dataset.treeKey
+    activeKey.value = flattenNodes(filteredTreeData.value).find((item) => String(item.key) === key)?.key ?? key
+    syncTreeNodeIds()
+  }
+}
 const searchExpandedKeys = computed(() => flattenNodes(filteredTreeData.value)
   .filter((node) => node.children?.length)
   .map((node) => node.key))
@@ -192,7 +232,12 @@ const handleTriggerKeydown = (event: KeyboardEvent) => {
   if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
     event.preventDefault()
     requestOpen(true)
-    void nextTick(() => panelRef.value?.querySelector<HTMLElement>('[data-tree-key][tabindex="0"]')?.focus())
+    void nextTick(() => {
+      syncTreeNodeIds()
+      const node = panelRef.value?.querySelector<HTMLElement>('[data-tree-key][tabindex="0"]')
+      if (node?.dataset.treeKey !== undefined) activeKey.value = node.dataset.treeKey
+      node?.focus()
+    })
   } else if (event.key === 'Escape' && mergedOpen.value) {
     event.preventDefault()
     requestOpen(false)

--- a/packages/components/src/utils/__tests__/overlay-controller.test.ts
+++ b/packages/components/src/utils/__tests__/overlay-controller.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isTargetInOverlayTree,
+  isTopmost,
+  getRecentPointerTarget,
+  lockBodyScroll,
+  prepareOverlayDocument,
+  registerOverlay,
+  unregisterOverlay,
+  unlockBodyScroll
+} from '../overlay-controller'
+
+describe('overlay-controller', () => {
+  afterEach(() => {
+    document.body.style.overflow = ''
+    document.body.style.paddingRight = ''
+  })
+
+  it('keeps a single document stack across overlay kinds and only reports the topmost layer', () => {
+    const modal = Symbol('modal')
+    const drawer = Symbol('drawer')
+    const onEscape = vi.fn()
+    registerOverlay({ id: modal, onEscape })
+    registerOverlay({ id: drawer, escapeEnabled: false, onEscape })
+
+    expect(isTopmost(drawer)).toBe(true)
+    expect(isTopmost(modal)).toBe(false)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    expect(onEscape).not.toHaveBeenCalled()
+
+    unregisterOverlay(drawer)
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    unregisterOverlay(modal)
+  })
+
+  it('stops a handled Escape before a component-local fallback can run', () => {
+    const overlay = Symbol('overlay')
+    const content = document.createElement('div')
+    document.body.appendChild(content)
+    const onEscape = vi.fn()
+    const localKeydown = vi.fn()
+    content.addEventListener('keydown', localKeydown)
+    registerOverlay({ id: overlay, getContent: () => content, onEscape })
+
+    content.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }))
+    expect(onEscape).toHaveBeenCalledTimes(1)
+    expect(localKeydown).not.toHaveBeenCalled()
+
+    unregisterOverlay(overlay)
+    content.remove()
+  })
+
+  it('recognizes teleported descendants opened from an overlay content', () => {
+    const parent = document.createElement('section')
+    const trigger = document.createElement('button')
+    const childContent = document.createElement('div')
+    const grandchildTrigger = document.createElement('button')
+    const grandchildContent = document.createElement('div')
+    parent.append(trigger)
+    childContent.append(grandchildTrigger)
+    document.body.append(parent, childContent, grandchildContent)
+    const parentId = Symbol('parent')
+    const childId = Symbol('child')
+    const grandchildId = Symbol('grandchild')
+    registerOverlay({ id: parentId, getContent: () => parent })
+    registerOverlay({ id: childId, getTrigger: () => trigger, getContent: () => childContent })
+    registerOverlay({ id: grandchildId, getTrigger: () => grandchildTrigger, getContent: () => grandchildContent })
+
+    expect(isTargetInOverlayTree(parentId, childContent)).toBe(true)
+    expect(isTargetInOverlayTree(parentId, grandchildContent)).toBe(true)
+    unregisterOverlay(grandchildId)
+    unregisterOverlay(childId)
+    unregisterOverlay(parentId)
+    parent.remove()
+    childContent.remove()
+    grandchildContent.remove()
+  })
+
+  it('reference-counts body scroll locking and restores the original value', () => {
+    document.body.style.overflow = 'auto'
+    document.body.style.paddingRight = '7px'
+    lockBodyScroll()
+    lockBodyScroll()
+    expect(document.body.style.overflow).toBe('hidden')
+    unlockBodyScroll()
+    expect(document.body.style.overflow).toBe('hidden')
+    unlockBodyScroll()
+    expect(document.body.style.overflow).toBe('auto')
+    expect(document.body.style.paddingRight).toBe('7px')
+  })
+
+  it('keeps blocking overlay visuals in stack order while respecting an explicit base', () => {
+    const modal = Symbol('modal')
+    const drawer = Symbol('drawer')
+    const modalZIndex = vi.fn()
+    const drawerZIndex = vi.fn()
+
+    registerOverlay({ id: modal, getBaseZIndex: () => 2000, onZIndexChange: modalZIndex })
+    registerOverlay({ id: drawer, getBaseZIndex: () => 1000, onZIndexChange: drawerZIndex })
+
+    expect(modalZIndex).toHaveBeenLastCalledWith(2000)
+    expect(drawerZIndex).toHaveBeenLastCalledWith(2010)
+    unregisterOverlay(drawer)
+    unregisterOverlay(modal)
+  })
+
+  it('tracks the pointer opener and clears it when keyboard input takes over', () => {
+    const trigger = document.createElement('button')
+    const label = document.createElement('span')
+    trigger.appendChild(label)
+    document.body.appendChild(trigger)
+    prepareOverlayDocument()
+
+    label.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, composed: true }))
+    expect(getRecentPointerTarget()).toBe(trigger)
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(getRecentPointerTarget()).toBeNull()
+
+    trigger.remove()
+  })
+})

--- a/packages/components/src/utils/__tests__/use-floating-dismiss.test.ts
+++ b/packages/components/src/utils/__tests__/use-floating-dismiss.test.ts
@@ -107,4 +107,129 @@ describe('useFloatingDismiss', () => {
     expect(document.activeElement).toBe(popup)
     scope.stop()
   })
+
+  it('treats a teleported child popup as inside its parent overlay tree', async () => {
+    const parentOpen = ref(true)
+    const childOpen = ref(true)
+    const parentTrigger = document.createElement('button')
+    const parentPopup = document.createElement('div')
+    const childTrigger = document.createElement('button')
+    const childPopup = document.createElement('div')
+    const outside = document.createElement('button')
+    parentPopup.appendChild(childTrigger)
+    document.body.append(parentTrigger, parentPopup, childPopup, outside)
+    const dismissParent = vi.fn(() => {
+      parentOpen.value = false
+    })
+    const dismissChild = vi.fn(() => {
+      childOpen.value = false
+    })
+    const scope = effectScope()
+
+    scope.run(() => {
+      useFloatingDismiss({
+        open: parentOpen,
+        trigger: ref(parentTrigger),
+        floating: ref(parentPopup),
+        onDismiss: dismissParent
+      })
+      useFloatingDismiss({
+        open: childOpen,
+        trigger: ref(childTrigger),
+        floating: ref(childPopup),
+        onDismiss: dismissChild
+      })
+    })
+
+    childPopup.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, composed: true }))
+    expect(dismissParent).not.toHaveBeenCalled()
+    expect(dismissChild).not.toHaveBeenCalled()
+
+    outside.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, composed: true }))
+    expect(dismissChild).toHaveBeenCalledTimes(1)
+    expect(dismissParent).not.toHaveBeenCalled()
+    await nextTick()
+
+    outside.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, composed: true }))
+    expect(dismissParent).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+
+  it('dismisses and restores focus for only the topmost nested overlay on Escape', async () => {
+    const parentOpen = ref(true)
+    const childOpen = ref(true)
+    const parentTrigger = document.createElement('button')
+    const parentPopup = document.createElement('div')
+    const childTrigger = document.createElement('button')
+    const childPopup = document.createElement('div')
+    parentPopup.appendChild(childTrigger)
+    document.body.append(parentTrigger, parentPopup, childPopup)
+    childPopup.tabIndex = 0
+    childPopup.focus()
+    const dismissParent = vi.fn(() => {
+      parentOpen.value = false
+    })
+    const dismissChild = vi.fn(() => {
+      childOpen.value = false
+    })
+    const scope = effectScope()
+
+    scope.run(() => {
+      useFloatingDismiss({
+        open: parentOpen,
+        trigger: ref(parentTrigger),
+        floating: ref(parentPopup),
+        onDismiss: dismissParent
+      })
+      useFloatingDismiss({
+        open: childOpen,
+        trigger: ref(childTrigger),
+        floating: ref(childPopup),
+        onDismiss: dismissChild
+      })
+    })
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(dismissChild).toHaveBeenCalledTimes(1)
+    expect(dismissParent).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(childTrigger)
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(dismissParent).toHaveBeenCalledTimes(1)
+    expect(document.activeElement).toBe(parentTrigger)
+    scope.stop()
+  })
+
+  it('keeps nested floating visuals in the same order as dismissal ownership', () => {
+    const parentPopup = document.createElement('div')
+    const childTrigger = document.createElement('button')
+    const childPopup = document.createElement('div')
+    parentPopup.style.zIndex = '1200'
+    childPopup.style.zIndex = '1100'
+    parentPopup.appendChild(childTrigger)
+    document.body.append(parentPopup, childPopup)
+    const scope = effectScope()
+
+    scope.run(() => {
+      useFloatingDismiss({
+        open: ref(true),
+        trigger: ref(document.createElement('button')),
+        floating: ref(parentPopup),
+        onDismiss: vi.fn()
+      })
+      useFloatingDismiss({
+        open: ref(true),
+        trigger: ref(childTrigger),
+        floating: ref(childPopup),
+        onDismiss: vi.fn()
+      })
+    })
+
+    expect(parentPopup.style.zIndex).toBe('1200')
+    expect(childPopup.style.zIndex).toBe('1210')
+    scope.stop()
+    expect(childPopup.style.zIndex).toBe('1100')
+  })
 })

--- a/packages/components/src/utils/__tests__/use-trigger-aria.test.ts
+++ b/packages/components/src/utils/__tests__/use-trigger-aria.test.ts
@@ -1,0 +1,41 @@
+import { effectScope, nextTick, ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useTriggerAria } from '../use-trigger-aria'
+
+describe('useTriggerAria', () => {
+  it('mirrors relationships to the focus target and restores its original attributes', async () => {
+    const root = document.createElement('span')
+    const button = document.createElement('button')
+    button.setAttribute('aria-describedby', 'existing-help')
+    root.appendChild(button)
+    const expanded = ref(false)
+    const scope = effectScope()
+    scope.run(() => useTriggerAria(ref(root), () => ({
+      'aria-describedby': 'popup-help',
+      'aria-expanded': expanded.value ? 'true' : 'false'
+    })))
+
+    await nextTick()
+    expect(button.getAttribute('aria-describedby')).toBe('existing-help popup-help')
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+    expanded.value = true
+    await nextTick()
+    await nextTick()
+    expect(button.getAttribute('aria-expanded')).toBe('true')
+
+    scope.stop()
+    expect(button.getAttribute('aria-describedby')).toBe('existing-help')
+    expect(button.hasAttribute('aria-expanded')).toBe(false)
+  })
+
+  it('does not assign focus semantics to a non-focusable wrapper', async () => {
+    const root = document.createElement('span')
+    root.textContent = 'Plain text'
+    const scope = effectScope()
+    scope.run(() => useTriggerAria(ref(root), () => ({ 'aria-controls': 'popup' })))
+
+    await nextTick()
+    expect(root.hasAttribute('aria-controls')).toBe(false)
+    scope.stop()
+  })
+})

--- a/packages/components/src/utils/overlay-controller.ts
+++ b/packages/components/src/utils/overlay-controller.ts
@@ -1,0 +1,216 @@
+export interface OverlayRegistration {
+  id: symbol
+  document?: Document
+  getTrigger?: () => Element | null | undefined
+  getContent?: () => Element | null | undefined
+  escapeEnabled?: boolean | (() => boolean)
+  getBaseZIndex?: () => number
+  onZIndexChange?: (zIndex: number) => void
+  onEscape?: (event: KeyboardEvent) => void
+  onPointerDownOutside?: (event: PointerEvent) => void
+}
+
+interface OverlayRecord extends OverlayRegistration {
+  document: Document
+}
+
+const records = new WeakMap<Document, OverlayRecord[]>()
+const listeners = new WeakMap<Document, { keydown: (event: KeyboardEvent) => void; pointerdown: (event: PointerEvent) => void }>()
+const locks = new WeakMap<Document, { count: number; overflow: string; paddingRight: string }>()
+const recentPointerTargets = new WeakMap<Document, { target: Element; recordedAt: number }>()
+const INTERACTIVE_SELECTOR = [
+  'button:not([disabled])',
+  'a[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',')
+
+const getRecords = (ownerDocument: Document) => {
+  let value = records.get(ownerDocument)
+  if (!value) {
+    value = []
+    records.set(ownerDocument, value)
+  }
+  return value
+}
+
+const isEscapeEnabled = (record: OverlayRecord) =>
+  typeof record.escapeEnabled === 'function' ? record.escapeEnabled() : record.escapeEnabled !== false
+
+const getElement = (getter: (() => Element | null | undefined) | undefined) => getter?.() ?? null
+
+export const getRecentPointerTarget = (ownerDocument: Document = document, maxAge = 500) => {
+  const recent = recentPointerTargets.get(ownerDocument)
+  return recent && Date.now() - recent.recordedAt <= maxAge ? recent.target : null
+}
+
+export const refreshOverlayStack = (ownerDocument: Document = document) => {
+  let previousZIndex = Number.NEGATIVE_INFINITY
+
+  for (const record of getRecords(ownerDocument)) {
+    if (!record.onZIndexChange) continue
+    const baseZIndex = record.getBaseZIndex?.() ?? 0
+    const zIndex = Number.isFinite(previousZIndex) ? Math.max(baseZIndex, previousZIndex + 10) : baseZIndex
+    record.onZIndexChange(zIndex)
+    previousZIndex = zIndex
+  }
+}
+
+const containsTarget = (record: OverlayRecord, targets: readonly EventTarget[]) => {
+  const NodeConstructor = record.document.defaultView?.Node
+  return targets.some((target) =>
+    Boolean(
+      NodeConstructor &&
+      target instanceof NodeConstructor &&
+      [getElement(record.getTrigger), getElement(record.getContent)].some((element) => element?.contains(target))
+    )
+  )
+}
+
+/** True when target is in this overlay or in an overlay opened from its content. */
+export const isTargetInOverlayTree = (
+  id: symbol,
+  target: EventTarget | null | readonly EventTarget[],
+  ownerDocument: Document = document
+) => {
+  const stack = getRecords(ownerDocument)
+  const record = stack.find((entry) => entry.id === id)
+  if (!record) return false
+  const targets = Array.isArray(target) ? target : [target]
+  if (containsTarget(record, targets)) return true
+
+  const getParent = (child: OverlayRecord) => {
+    const childIndex = stack.indexOf(child)
+    const childTrigger = getElement(child.getTrigger)
+    const childContent = getElement(child.getContent)
+
+    for (let index = childIndex - 1; index >= 0; index -= 1) {
+      const candidate = stack[index]
+      const candidateContent = getElement(candidate.getContent)
+      if (candidateContent && (candidateContent.contains(childTrigger) || candidateContent.contains(childContent))) {
+        return candidate
+      }
+    }
+  }
+
+  return stack.some((candidate) => {
+    if (candidate.id === id || !containsTarget(candidate, targets)) return false
+    const visited = new Set<symbol>()
+    let parent = getParent(candidate)
+
+    while (parent && !visited.has(parent.id)) {
+      if (parent.id === id) return true
+      visited.add(parent.id)
+      parent = getParent(parent)
+    }
+
+    return false
+  })
+}
+
+const ensureListeners = (ownerDocument: Document) => {
+  if (listeners.has(ownerDocument)) return
+  const keydown = (event: KeyboardEvent) => {
+    recentPointerTargets.delete(ownerDocument)
+    if (event.key !== 'Escape') return
+    const stack = getRecords(ownerDocument)
+    const top = stack[stack.length - 1]
+    if (!top) return
+    event.preventDefault()
+    event.stopPropagation()
+    if (isEscapeEnabled(top)) top.onEscape?.(event)
+  }
+  const pointerdown = (event: PointerEvent) => {
+    const ElementConstructor = ownerDocument.defaultView?.Element
+    const pathTarget = (event.composedPath?.() ?? [event.target]).find(
+      (target) => ElementConstructor && target instanceof ElementConstructor
+    )
+    const pathElement = ElementConstructor && pathTarget instanceof ElementConstructor ? pathTarget as Element : null
+    const pointerTarget = pathElement?.closest(INTERACTIVE_SELECTOR) ?? pathElement
+    if (pointerTarget) recentPointerTargets.set(ownerDocument, { target: pointerTarget, recordedAt: Date.now() })
+    const stack = getRecords(ownerDocument)
+    const top = stack[stack.length - 1]
+    const path = event.composedPath?.() ?? [event.target]
+    if (!top || !top.onPointerDownOutside || isTargetInOverlayTree(top.id, path, ownerDocument)) return
+    top.onPointerDownOutside(event)
+  }
+  ownerDocument.addEventListener('keydown', keydown, true)
+  ownerDocument.addEventListener('pointerdown', pointerdown, true)
+  listeners.set(ownerDocument, { keydown, pointerdown })
+}
+
+/** Installs the lightweight input tracker before a closed blocking overlay is opened. */
+export const prepareOverlayDocument = (ownerDocument: Document = document) => {
+  ensureListeners(ownerDocument)
+}
+
+export const registerOverlay = (registration: OverlayRegistration) => {
+  const ownerDocument = registration.document ?? document
+  const stack = getRecords(ownerDocument)
+  const existing = stack.findIndex((entry) => entry.id === registration.id)
+  if (existing >= 0) stack.splice(existing, 1)
+  stack.push({ ...registration, document: ownerDocument })
+  refreshOverlayStack(ownerDocument)
+  ensureListeners(ownerDocument)
+
+  return () => unregisterOverlay(registration.id, ownerDocument)
+}
+
+export const updateOverlay = (id: symbol, patch: Partial<Omit<OverlayRegistration, 'id' | 'document'>>, ownerDocument: Document = document) => {
+  const record = getRecords(ownerDocument).find((entry) => entry.id === id)
+  if (record) {
+    Object.assign(record, patch)
+    refreshOverlayStack(ownerDocument)
+  }
+}
+
+export const unregisterOverlay = (id: symbol, ownerDocument: Document = document) => {
+  const stack = getRecords(ownerDocument)
+  const index = stack.findIndex((entry) => entry.id === id)
+  if (index >= 0) stack.splice(index, 1)
+  refreshOverlayStack(ownerDocument)
+
+  if (stack.length === 0) {
+    records.delete(ownerDocument)
+  }
+}
+
+export const isTopmost = (id: symbol, ownerDocument: Document = document) => {
+  const stack = getRecords(ownerDocument)
+  return stack[stack.length - 1]?.id === id
+}
+
+export const lockBodyScroll = (ownerDocument: Document = document) => {
+  const body = ownerDocument.body
+  if (!body) return
+  const state = locks.get(ownerDocument)
+  if (state) {
+    state.count += 1
+    return
+  }
+  const paddingRight = body.style.paddingRight
+  const viewportWidth = ownerDocument.defaultView?.innerWidth ?? 0
+  const contentWidth = ownerDocument.documentElement.clientWidth
+  const scrollbarWidth = contentWidth > 0 ? Math.max(0, viewportWidth - contentWidth) : 0
+  locks.set(ownerDocument, { count: 1, overflow: body.style.overflow, paddingRight })
+
+  if (scrollbarWidth > 0) {
+    const currentPadding = Number.parseFloat(ownerDocument.defaultView?.getComputedStyle(body).paddingRight ?? '0') || 0
+    body.style.paddingRight = `${currentPadding + scrollbarWidth}px`
+  }
+  body.style.overflow = 'hidden'
+}
+
+export const unlockBodyScroll = (ownerDocument: Document = document) => {
+  const state = locks.get(ownerDocument)
+  if (!state) return
+  state.count -= 1
+  if (state.count > 0) return
+  if (ownerDocument.body) {
+    ownerDocument.body.style.overflow = state.overflow
+    ownerDocument.body.style.paddingRight = state.paddingRight
+  }
+  locks.delete(ownerDocument)
+}

--- a/packages/components/src/utils/use-floating-dismiss.ts
+++ b/packages/components/src/utils/use-floating-dismiss.ts
@@ -1,4 +1,5 @@
 import { nextTick, onScopeDispose, toValue, watchEffect, type MaybeRefOrGetter } from 'vue'
+import { registerOverlay } from './overlay-controller'
 
 type ElementSource = MaybeRefOrGetter<HTMLElement | null | undefined>
 
@@ -13,11 +14,15 @@ export interface UseFloatingDismissOptions {
 }
 
 export function useFloatingDismiss(options: UseFloatingDismissOptions) {
-  let removeListeners: (() => void) | undefined
+  const overlayId = Symbol('aheart-floating-overlay')
+  let unregister: (() => void) | undefined
+  let restoreZIndex: (() => void) | undefined
 
   const cleanup = () => {
-    removeListeners?.()
-    removeListeners = undefined
+    unregister?.()
+    unregister = undefined
+    restoreZIndex?.()
+    restoreZIndex = undefined
   }
 
   const focusTrigger = () => {
@@ -46,39 +51,49 @@ export function useFloatingDismiss(options: UseFloatingDismissOptions) {
       return
     }
 
-    const handlePointerDown = (event: PointerEvent) => {
-      const trigger = toValue(options.trigger)
-      const floating = toValue(options.floating)
-      const path = event.composedPath()
+    const trigger = toValue(options.trigger)
+    const floating = toValue(options.floating)
+    const ownerDocument = trigger?.ownerDocument ?? floating?.ownerDocument ?? document
+    const HTMLElementConstructor = ownerDocument.defaultView?.HTMLElement
+    const floatingElement = HTMLElementConstructor && floating instanceof HTMLElementConstructor
+      ? floating as HTMLElement
+      : null
+    const originalZIndex = floatingElement?.style.zIndex ?? ''
+    const computedZIndex = Number.parseFloat(
+      floatingElement ? ownerDocument.defaultView?.getComputedStyle(floatingElement).zIndex ?? '' : ''
+    )
+    const baseZIndex = Number.isFinite(computedZIndex) ? computedZIndex : 0
+    restoreZIndex = floatingElement
+      ? () => {
+          floatingElement.style.zIndex = originalZIndex
+        }
+      : undefined
+    unregister = registerOverlay({
+      id: overlayId,
+      document: ownerDocument,
+      getTrigger: () => toValue(options.trigger),
+      getContent: () => toValue(options.floating),
+      escapeEnabled: () => toValue(options.open),
+      getBaseZIndex: () => baseZIndex,
+      onZIndexChange: (zIndex) => {
+        const content = toValue(options.floating)
+        if (HTMLElementConstructor && content instanceof HTMLElementConstructor) {
+          ;(content as HTMLElement).style.zIndex = String(zIndex)
+        }
+      },
+      onPointerDownOutside: (event) => {
+        if (toValue(options.open)) options.onDismiss('outside', event)
+      },
+      onEscape: (event) => {
+        options.onDismiss('escape', event)
 
-      if ((trigger && path.includes(trigger)) || (floating && path.includes(floating))) {
-        return
+        if (toValue(options.restoreFocus) !== false) {
+          void nextTick(() => {
+            if (!toValue(options.open)) focusTrigger()
+          })
+        }
       }
-
-      options.onDismiss('outside', event)
-    }
-
-    const handleKeydown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') {
-        return
-      }
-
-      event.preventDefault()
-      options.onDismiss('escape', event)
-
-      if (toValue(options.restoreFocus) !== false) {
-        void nextTick(() => {
-          if (!toValue(options.open)) focusTrigger()
-        })
-      }
-    }
-
-    document.addEventListener('pointerdown', handlePointerDown, true)
-    document.addEventListener('keydown', handleKeydown, true)
-    removeListeners = () => {
-      document.removeEventListener('pointerdown', handlePointerDown, true)
-      document.removeEventListener('keydown', handleKeydown, true)
-    }
+    })
     onCleanup(cleanup)
   })
 

--- a/packages/components/src/utils/use-trigger-aria.ts
+++ b/packages/components/src/utils/use-trigger-aria.ts
@@ -1,0 +1,75 @@
+import { nextTick, onScopeDispose, toValue, watchEffect, type MaybeRefOrGetter } from 'vue'
+
+type TriggerAriaValue = string | undefined
+type TriggerAriaAttributes = Record<`aria-${string}`, TriggerAriaValue>
+
+const FOCUSABLE_SELECTOR = [
+  'button:not([disabled])',
+  'a[href]',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',')
+
+const TOKEN_ATTRIBUTES = new Set(['aria-describedby', 'aria-labelledby'])
+
+/** Mirrors wrapper-owned popup relationships onto the actual slotted focus target. */
+export const useTriggerAria = (
+  rootSource: MaybeRefOrGetter<HTMLElement | null | undefined>,
+  getAttributes: () => TriggerAriaAttributes
+) => {
+  let sequence = 0
+  let target: HTMLElement | null = null
+  let originals = new Map<string, string | null>()
+
+  const restore = () => {
+    if (!target) return
+    for (const [name, value] of originals) {
+      if (value === null) target.removeAttribute(name)
+      else target.setAttribute(name, value)
+    }
+    target = null
+    originals = new Map()
+  }
+
+  watchEffect(() => {
+    const root = toValue(rootSource)
+    const attributes = getAttributes()
+    const currentSequence = ++sequence
+
+    void nextTick(() => {
+      if (currentSequence !== sequence) return
+      const nextTarget = root?.matches(FOCUSABLE_SELECTOR)
+        ? root
+        : root?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? null
+
+      if (nextTarget !== target) {
+        restore()
+        target = nextTarget
+      }
+      if (!target) return
+
+      for (const [name, value] of Object.entries(attributes)) {
+        if (!originals.has(name)) originals.set(name, target.getAttribute(name))
+        const original = originals.get(name)
+
+        if (value === undefined) {
+          if (original === null) target.removeAttribute(name)
+          else if (original !== undefined) target.setAttribute(name, original)
+          continue
+        }
+
+        const resolvedValue = TOKEN_ATTRIBUTES.has(name) && original
+          ? Array.from(new Set([...original.split(/\s+/), value])).join(' ')
+          : value
+        target.setAttribute(name, resolvedValue)
+      }
+    })
+  })
+
+  onScopeDispose(() => {
+    sequence += 1
+    restore()
+  })
+}

--- a/scripts/overlay-focus-build.test.mjs
+++ b/scripts/overlay-focus-build.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { existsSync, readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const root = new URL('..', import.meta.url)
+const internalHelpers = ['overlay-controller', 'use-trigger-aria']
+
+test('D2 overlay helpers stay internal and ship paired ESM and CommonJS files', () => {
+  const publicEntry = readFileSync(new URL('./packages/components/src/index.ts', root), 'utf8')
+
+  for (const helper of internalHelpers) {
+    assert.doesNotMatch(publicEntry, new RegExp(`utils/${helper}`))
+    for (const format of ['es', 'lib']) {
+      assert.equal(existsSync(new URL(`./packages/components/${format}/utils/${helper}.d.ts`, root)), true)
+      assert.equal(existsSync(new URL(`./packages/components/${format}/utils/${helper}.js`, root)), true)
+    }
+  }
+
+  for (const format of ['es', 'lib']) {
+    const dismiss = readFileSync(new URL(`./packages/components/${format}/utils/use-floating-dismiss.js`, root), 'utf8')
+    assert.match(dismiss, /overlay-controller/)
+  }
+})


### PR DESCRIPTION
## 发布检查

- [x] 已说明影响的产品任务及验收目标
- [x] 已确认质量矩阵更新，或说明本次无需更新

嵌套 Modal、Drawer 和 Teleport 弹层现共用 document 级堆栈：Escape/外部点击仅分发给顶层，视觉层级与焦点一致，最后一个阻塞层离场后释放滚动锁。修复 WebKit 点击开启者未获焦点时的恢复，补齐 Cascader/TreeSelect 和提示类组件的 ARIA 关联。

公开 props/events、包边界和依赖保持现状。新增模块为内部 helper。质量矩阵保留既有组件证据，新增混合浮层真实浏览器契约在 cross-browser-r1.spec.ts，完整四角色记录在 docs/superpowers/reviews/2026-09-06-d2-overlay-focus.md。

验证：components 66 files / 1026 tests，DnD 44、AI 63、scripts 86；类型检查、两次构建确定性、三包打包契约、docs build 通过。D2 五浏览器路径 5/5，Desktop WebKit R1 9/9，QG4 desktop 14 passed / 3 skipped。开发/测试复审 P1/P2=0。实体 iOS Safari 属于独立门禁。

候选提交：ece7e836f3508fad6088ac0dd506260ce76c5db0。等待 PR CI 后合并，并继续核对 master CI/Pages。
