### PR TITLE
D7 follow-up: stabilize WebKit filter viewport

### DIFF
--- a/docs/superpowers/evidence/d7/post-merge/01-master-ci-webkit-filter-red.md
+++ b/docs/superpowers/evidence/d7/post-merge/01-master-ci-webkit-filter-red.md
@@ -1,0 +1,52 @@
+# D7 post-merge master CI repair RED: WebKit filter geometry
+
+Date: 2026-09-09
+
+## Failure being reproduced
+
+The first master CI run after D7 PR #22 was squash-merged at `cf2776f301f055fb4a02486e434d30dc2183c7fc` failed in `desktop-webkit` for:
+
+`D5-B filter draft confirm, reset, cancel, keyboard, outside, and controlled rejection`
+
+The authoritative run is [master CI run 34329397392](https://github.com/wzfdhr/aheart-ui/actions/runs/34329397392). Its failure timed out in `openFilter(page, demo, 1)` at the existing geometry poll (`e2e/d5-table-b.spec.ts:37`), after the page had drifted down to the Theme Tokens section and the second filter trigger was outside the viewport.
+
+## Deterministic RED setup
+
+The test now adds one precondition immediately before the second-filter call:
+
+```ts
+await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+popup = await openFilter(page, demo, 1)
+```
+
+This deliberately reproduces the post-navigation vertical scroll state. The helper and its timeout, hit-test, geometry assertions, and popup assertions are unchanged. No `force`, `skip`, or assertion weakening was used.
+
+## Exact reproduction
+
+Command (isolated port):
+
+```sh
+AHEART_E2E_PORT=5312 corepack pnpm exec playwright test e2e/d5-table-b.spec.ts --project=desktop-webkit --grep="D5-B filter draft confirm, reset, cancel, keyboard, outside, and controlled rejection"
+```
+
+Result: **1 failed**, at `openFilter` line 37, with `expect.poll` timing out after 5000 ms (`Expected: true`, `Received: false`). The failure produced the local screenshot, video, trace, and error context under:
+
+`test-results/d5-table-b-D5-B-filter-dra-eb0e9-de-and-controlled-rejection-desktop-webkit/`
+
+Repeat command:
+
+```sh
+AHEART_E2E_PORT=5313 corepack pnpm exec playwright test e2e/d5-table-b.spec.ts --project=desktop-webkit --grep="D5-B filter draft confirm, reset, cancel, keyboard, outside, and controlled rejection" --repeat-each=3
+```
+
+Result: **3 failed / 3 runs**, all at the same geometry poll in `openFilter` line 37. Repeat artifacts are under the corresponding `test-results/...-repeat1` and `...-repeat2` directories.
+
+The original master-run screenshot remains available at:
+
+`/tmp/aheart-d7-master-ci-evidence.NJwaGt/test-results/d5-table-b-D5-B-filter-dra-eb0e9-de-and-controlled-rejection-desktop-webkit/test-failed-1.png`
+
+## RED conclusion
+
+The failure is real and repeatable: when the page is vertically scrolled away from the table, the existing helper never establishes the required `elementFromPoint`/container geometry for trigger index 1. The next repair must make the trigger visible before horizontal geometry setup; this RED phase intentionally does not include that fix.
+
+`git diff --check`: passed.

--- a/docs/superpowers/evidence/d7/post-merge/02-master-ci-webkit-filter-green.md
+++ b/docs/superpowers/evidence/d7/post-merge/02-master-ci-webkit-filter-green.md
@@ -1,0 +1,38 @@
+# D7 post-merge master CI repair GREEN: WebKit filter geometry
+
+Date: 2026-09-09
+
+## Repair
+
+The post-merge master run `34329397392` exposed a real viewport-state failure in
+`openFilter(page, demo, 1)`: the page could be vertically scrolled away from the
+table before the helper established the horizontal fixed-column geometry. The
+helper now calls `scrollIntoViewIfNeeded()` for the requested trigger before
+setting the table container's `scrollLeft`. The existing geometry boundary,
+`elementFromPoint` hit-test, timeout, popup, and pageerror/console-error
+assertions are unchanged. The deterministic scroll-to-bottom RED precondition is
+retained in the test.
+
+No product source was changed. No timeout was extended, no `force` or `skip` was
+introduced, and no assertion was removed or weakened.
+
+## Verification
+
+Exact desktop WebKit regression command (isolated port `5314`):
+
+```sh
+AHEART_E2E_PORT=5314 corepack pnpm exec playwright test e2e/d5-table-b.spec.ts --project=desktop-webkit --grep="D5-B filter draft confirm, reset, cancel, keyboard, outside, and controlled rejection" --repeat-each=5
+```
+
+Result: **5 passed, 0 failed** in 12.2 seconds.
+
+Five-project affected test command (isolated port `5315`):
+
+```sh
+AHEART_E2E_PORT=5315 corepack pnpm exec playwright test e2e/d5-table-b.spec.ts --project=desktop --project=mobile --project=desktop-firefox --project=desktop-webkit --project=mobile-webkit --grep="D5-B filter draft confirm, reset, cancel, keyboard, outside, and controlled rejection"
+```
+
+Result: **5 passed, 0 failed** in 13.1 seconds. The existing test listener
+reported no page errors or console errors.
+
+`git diff --check`: passed.

--- a/docs/superpowers/evidence/d7/post-merge/03-full-e2e-green.md
+++ b/docs/superpowers/evidence/d7/post-merge/03-full-e2e-green.md
@@ -1,0 +1,13 @@
+# D7 post-merge full E2E gate
+
+- Run timestamp (UTC): 2026-09-09T09:43:36Z
+- Base checkout: `cf2776f301f055fb4a02486e434d30dc2183c7fc` (merge commit for PR #22), with the reviewed post-merge repair diff applied in the working tree. The repair commit SHA is recorded after candidate freeze rather than being guessed here.
+- Command: `CI=1 AHEART_E2E_PORT=5326 corepack pnpm exec playwright test`
+- Execution shape: Playwright single worker, 750 tests
+- Result: **623 passed, 127 skipped, 0 failed**
+- Duration: **18.0 minutes**
+- Skip delta: no new skips observed; the 127 skips match the existing repository applicability skips.
+- Master CI regression: the previously failing `desktop-webkit` D5-B filter draft/confirm/reset/cancel/keyboard/outside/controlled-rejection test passed in this full run.
+- `git diff --check`: passed.
+
+The run completed with exit code 0. The Playwright `test-results/` output was retained in the checkout for inspection; no failed test artifacts were produced by this run.

--- a/docs/superpowers/reviews/2026-09-09-d7-post-merge-ci-repair-review.md
+++ b/docs/superpowers/reviews/2026-09-09-d7-post-merge-ci-repair-review.md
@@ -1,0 +1,73 @@
+# D7 post-merge CI repair independent test-manager review
+
+Date: 2026-09-09
+
+## Scope and baseline
+
+This review covers the repair diff on `codex/d7-master-ci-repair` against the
+merged D7 baseline `cf2776f301f055fb4a02486e434d30dc2183c7fc` (PR #22).
+The authoritative post-merge failure was master CI run
+[34329397392](https://github.com/wzfdhr/aheart-ui/actions/runs/34329397392):
+the desktop WebKit D5-B filter test timed out in `openFilter(page, demo, 1)`
+while the page was vertically scrolled away from the table.
+
+## Line-by-line review
+
+The repair has two test-only changes in `e2e/d5-table-b.spec.ts`:
+
+1. In `openFilter`, the requested second trigger is made vertically visible
+   with `scrollIntoViewIfNeeded()` before the existing horizontal
+   `scrollLeft = scrollWidth` setup. The existing fixed-column boundary,
+   `elementFromPoint` hit test, geometry assertions, poll timeout, click, and
+   popup assertions are unchanged.
+2. The main D5-B filter test intentionally scrolls to the document bottom
+   immediately before `openFilter(page, demo, 1)`, preserving a deterministic
+   regression precondition for the master-CI viewport drift.
+
+No production source, public API, timeout, `force`, `skip`, retry policy, or
+assertion was changed. The diff does not weaken coverage or hide a product
+failure; it makes the test helper establish the page state required by its
+existing geometry assertion.
+
+## RED evidence
+
+The preserved RED record is
+`docs/superpowers/evidence/d7/post-merge/01-master-ci-webkit-filter-red.md`.
+Without the visibility repair, the deterministic scroll-to-bottom precondition
+failed 1/1 and 3/3 repeated desktop-WebKit runs at the existing 5-second
+geometry poll. This matches the post-merge master failure and is a real,
+repeatable helper-state defect.
+
+## Independent GREEN verification
+
+Command, run on an exclusive port:
+
+```sh
+AHEART_E2E_PORT=5324 corepack pnpm exec playwright test e2e/d5-table-b.spec.ts \
+  --project=desktop --project=mobile --project=desktop-firefox \
+  --project=desktop-webkit --project=mobile-webkit
+```
+
+Result: **40 passed, 0 failed** in 35.3 seconds. All five configured browser
+projects completed the complete D5-B spec, including the deterministic
+scroll-drift regression path. No page or console errors were reported by the
+spec listeners.
+
+`git diff --check`: passed.
+
+## Gate decision
+
+| Gate | Result |
+| --- | --- |
+| Scope limited to test helper/page-state precondition | PASS |
+| Real RED retained and reproducible | PASS |
+| No timeout expansion, force, skip, or assertion weakening | PASS |
+| Complete five-browser D5-B spec | PASS (40/40) |
+| P0 | 0 |
+| P1 | 0 |
+| P2 | 0 |
+
+**Independent test-manager decision: PASS. The repair PR is approved for the
+next review/CI stage.** This approval is limited to the repair diff and does
+not substitute for the required repair-PR CI, post-merge master CI, Pages, or
+live verification gates.

--- a/docs/superpowers/status/2026-09-09-d7-status.md
+++ b/docs/superpowers/status/2026-09-09-d7-status.md
@@ -6,6 +6,7 @@
 - 审核：架构、开发、设计、独立测试、独立产品均通过，P0/P1/P2=`0/0/0`。
 - 自动化：components `1235`、DnD `79`、AI `66`、scripts `88`；D7 `25/25`；D7+legacy `135/50/0`；全仓最终 E2E `623 passed / 127 existing platform skips / 0 failed`；typecheck、deterministic build、generated、docs、pack `995/79/111` 通过。
 - 真实包：无 workspace symlink；types/ESM/CJS/CSS/SSR/hydration/keyboard/stable key/revision/rollback/owner cleanup 通过；tarball SHA-256 `9cea27e357f1b42376f2b0147dd2448fcab0500f2627a66c106b98dc7f8ee20d`。
-- 当前交付状态：允许创建 Ready PR；PR CI、squash merge、master CI、Pages 和线上 DnD 仍待继续完成，因此此刻不提前称 D7 整体关闭。
+- 交付历史：[PR #22](https://github.com/wzfdhr/aheart-ui/pull/22) 已以 `cf2776f301f055fb4a02486e434d30dc2183c7fc` squash merge；该 merge commit 的 [master CI 34329397392](https://github.com/wzfdhr/aheart-ui/actions/runs/34329397392) 在 desktop WebKit 的 D5-B 筛选测试 helper 几何轮询失败，因此 Pages 正确跳过，D7 没有被提前关闭。
+- 修复候选：分支 `codex/d7-master-ci-repair` 在原失败路径前加入确定性页面滚动 RED，仅让 `openFilter` 在横向布局校验前将目标触发器滚入纵向可见区；没有改生产码、timeout、force、skip 或断言。RED `3/3` 失败，GREEN WebKit `5/5`、五浏览器单用例 `5/5`、独立完整 D5-B `40/40`、全仓单 worker E2E `623 passed / 127 existing skips / 0 failed`。组件 `1235`、DnD `79`、AI `66`、scripts `88`，typecheck、deterministic build、generated、docs 和 release pack `995/79/111` 全绿，独立复审 P0/P1/P2=`0/0/0`。
+- 当前交付状态：修复候选本地门禁通过，可创建 Ready repair PR；仍需匹配最终 head SHA 的 PR CI、squash merge、新 master CI、Pages 和线上 DnD 验证，才能关闭 D7。
 - 边界：D8、D4 三组件延期虚拟化、D0-D3 最终复核、D9 物理设备与 npm 发布均未启动；aheart-ui v2 继续暂停。
-

--- a/e2e/d5-table-b.spec.ts
+++ b/e2e/d5-table-b.spec.ts
@@ -20,6 +20,7 @@ async function openFilter(page: Page, demo: ReturnType<Page['locator']>, index =
   const triggers = demo.locator('button[aria-haspopup="dialog"]')
   if (index > 0) {
     const container = demo.locator('.aheart-table__container')
+    await triggers.nth(index).scrollIntoViewIfNeeded()
     await container.evaluate(element => { element.scrollLeft = element.scrollWidth })
     const fixedBoundary = demo.locator('thead th').nth(2)
     await expect.poll(async () => {
@@ -129,6 +130,10 @@ test('D5-B filter draft confirm, reset, cancel, keyboard, outside, and controlle
   await page.keyboard.press('Escape')
   await expect(page.locator('[data-table-filter-popup]')).toHaveCount(0)
 
+  // Reproduce the post-navigation viewport drift seen in the master WebKit run:
+  // the second trigger can be vertically outside the viewport before the helper
+  // establishes the horizontal fixed-column geometry.
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
   popup = await openFilter(page, demo, 1)
   await page.mouse.click(1000, 100)
   await expect(page.locator('[data-table-filter-popup]')).toHaveCount(0)


### PR DESCRIPTION
## Why

D7 PR #22 merged successfully, but master CI run 34329397392 exposed a deterministic viewport-state defect in the D5-B Playwright helper: the second filter trigger could remain vertically outside the viewport while the helper waited for horizontal fixed-column hit-test geometry. Pages correctly stayed blocked.

## Change

- Preserve a scroll-to-document-bottom regression precondition.
- Make the requested filter trigger vertically visible before applying horizontal table scroll.
- Keep the existing geometry, hit-test, popup, pageerror, and console-error assertions unchanged.
- No production source or public API changes; no timeout increase, force, retry, skip, or assertion weakening.

## Review and verification

- RED: desktop WebKit failed 3/3 before the helper repair.
- GREEN: desktop WebKit 5/5.
- Independent complete D5-B matrix: 40/40 across five browser projects.
- Full repository CI-shaped E2E: 623 passed / 127 existing skips / 0 failed, 750 total, one worker.
- Components 1235, DnD 79, AI 66, scripts 88.
- typecheck, deterministic build, generated-output check, docs build, release packs 995/79/111, and git diff check passed.
- Independent test-manager review: P0/P1/P2 = 0/0/0.

## Delivery boundary

This is the required D7 post-merge repair. D7 remains open until this exact-head PR CI passes, the repair is squash-merged, and the new master CI, Pages, and live DnD checks pass. D8, deferred virtualization, D0-D3 review, D9 publication, npm release, and aheart-ui v2 are not included.